### PR TITLE
Build fails on co-hosted Jenkins/Chef Server (component OpenResty on port 9999)

### DIFF
--- a/src/test/java/io/prometheus/wls/rest/WebClientImplTest.java
+++ b/src/test/java/io/prometheus/wls/rest/WebClientImplTest.java
@@ -32,7 +32,7 @@ public class WebClientImplTest extends HttpUserAgentTest {
     private static final String UNDEFINED_HOST_URL = "http://mxyptlk/";
 
     /** A URL on a known host with a port on which no server is listening. */
-    private static final String UNDEFINED_PORT_URL = "http://localhost:9999";
+    private static final String UNDEFINED_PORT_URL = "http://localhost:59236";
 
     private WebClientFactory factory = new WebClientFactoryImpl();
 


### PR DESCRIPTION
Please could we change the test port to something that is less likely to cause build issues. OpenResty is a component of Chef Server and so the test fails in my co-located Jenkins server as the port is in use.

Tests run: 20, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.585 sec <<< FAILURE!
whenUnableToReachServer_throwException(io.prometheus.wls.rest.WebClientImplTest)  Time elapsed: 0.024 sec  <<< FAILURE!
java.lang.AssertionError: Expected exception: io.prometheus.wls.rest.WebClientException
	at org.junit.internal.runners.statements.ExpectException.evaluate(ExpectException.java:32)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)