### PR TITLE
Address server-side request forgery vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,12 @@ The exporter produces metrics for monitoring its own performance:
 - `wls_scrape_duration_seconds` reports the time required to do the scrape
 - `wls_scrape_cpu_seconds` reports the CPU time used during the scrape
 
+
+## Configuration
+
+The exporter uses `localhost` to access the REST API, so that needs not to be disabled.
  
 ## Copyright
  
- Copyright (c) 2017-2018 Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
 

--- a/src/main/java/io/prometheus/wls/rest/ErrorLog.java
+++ b/src/main/java/io/prometheus/wls/rest/ErrorLog.java
@@ -1,0 +1,35 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package io.prometheus.wls.rest;
+
+class ErrorLog {
+    private StringBuilder errors = new StringBuilder();
+
+    /**
+     * Report an exception.
+     * @param throwable the exception
+     */
+    void log(Throwable throwable) {
+        errors.append(toLogMessage(throwable));
+        for (Throwable cause = throwable.getCause(); cause != null; cause = cause.getCause())
+            errors.append(System.lineSeparator()).append("  ").append(toLogMessage(cause));
+    }
+
+    private String toLogMessage(Throwable throwable) {
+        StringBuilder sb = new StringBuilder(throwable.getClass().getSimpleName());
+        if (throwable.getMessage() != null && throwable.getMessage().trim().length() > 0)
+            sb.append(": ").append(throwable.getMessage());
+
+        return sb.toString();
+    }
+
+    /**
+     * returns the current error log.
+     * @return a string of errors, separated by line breaks.
+     */
+    String getErrors() {
+        return errors.toString();
+    }
+}

--- a/src/main/java/io/prometheus/wls/rest/LiveConfiguration.java
+++ b/src/main/java/io/prometheus/wls/rest/LiveConfiguration.java
@@ -24,7 +24,12 @@ import java.util.Map;
  * @author Russell Gold
  */
 class LiveConfiguration {
+    /** The path to the configuration file within the web application. */
     static final String CONFIG_YML = "/config.yml";
+
+    /** The address used to access WLS (cannot use the address found in the request due to potential server-side request forgery. */
+    static final String WLS_HOST = "localhost";
+    
     private static final String URL_PATTERN = "http://%s:%d/management/weblogic/latest/serverRuntime/search";
     private static ExporterConfig config;
     private static String serverName;
@@ -65,7 +70,7 @@ class LiveConfiguration {
      * @return a url built for the configured server
      */
     static String getQueryUrl() {
-        return String.format(URL_PATTERN, serverName, serverPort);
+        return String.format(URL_PATTERN, WLS_HOST, serverPort);
     }
 
     /**

--- a/src/main/java/io/prometheus/wls/rest/LogServlet.java
+++ b/src/main/java/io/prometheus/wls/rest/LogServlet.java
@@ -1,0 +1,26 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package io.prometheus.wls.rest;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet(value = "/" + ServletConstants.LOG_PAGE)
+public class LogServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String errors = LiveConfiguration.getErrors();
+        if (errors == null || errors.trim().length() == 0)
+            resp.getOutputStream().println("No errors reported.");
+        else
+            resp.getOutputStream().println("<blockquote>" + errors + "</blockquote>");
+
+        resp.getOutputStream().close();
+    }
+}

--- a/src/main/java/io/prometheus/wls/rest/ServletConstants.java
+++ b/src/main/java/io/prometheus/wls/rest/ServletConstants.java
@@ -1,6 +1,6 @@
 package io.prometheus.wls.rest;
 /*
- * Copyright (c) 2017-2018 Oracle and/or its affiliates
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
  */
@@ -24,6 +24,7 @@ public interface ServletConstants {
     String MAIN_PAGE = "";
     String METRICS_PAGE = "metrics";
     String CONFIGURATION_PAGE = "configure";
+    String LOG_PAGE = "log";
 
     /** The header used by a web client to send its authentication credentials. **/
     String AUTHENTICATION_HEADER = "Authorization";

--- a/src/main/java/io/prometheus/wls/rest/WebClientException.java
+++ b/src/main/java/io/prometheus/wls/rest/WebClientException.java
@@ -1,6 +1,6 @@
 package io.prometheus.wls.rest;
 /*
- * Copyright (c) 2017 Oracle and/or its affiliates
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
  */
@@ -10,6 +10,10 @@ package io.prometheus.wls.rest;
  */
 class WebClientException extends RuntimeException {
     WebClientException() {}
+
+    WebClientException(String message) {
+        super(message);
+    }
 
     WebClientException(Throwable cause, String message, Object... args) {
         super(formatMessage(message, args), cause);

--- a/src/test/java/io/prometheus/wls/rest/ErrorLogTest.java
+++ b/src/test/java/io/prometheus/wls/rest/ErrorLogTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+ */
+package io.prometheus.wls.rest;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static io.prometheus.wls.rest.ErrorLogTest.LogMatcher.containsErrors;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+public class ErrorLogTest {
+    private ErrorLog errorLog = new ErrorLog();
+
+    @Test
+    public void afterExceptionReported_isAddedToLog() {
+        errorLog.log(new IOException("Unable to read value"));
+
+        assertThat(errorLog, containsErrors("IOException: Unable to read value"));
+    }
+
+    @Test
+    public void afterExceptionWithNoMessageReported_logSimpleNameOnly() {
+        errorLog.log(new IOException());
+
+        assertThat(errorLog, containsErrors("IOException"));
+    }
+
+    @Test
+    public void afterExceptionWithNestedThrowableReported_addToLog() {
+        errorLog.log(new IOException("Unable to read value", new RuntimeException("has impossible format")));
+
+        assertThat(errorLog, containsErrors("IOException: Unable to read value", "  RuntimeException: has impossible format"));
+    }
+
+    @SuppressWarnings("unused")
+    static class LogMatcher extends TypeSafeDiagnosingMatcher<ErrorLog> {
+        private String[] expectedMessages;
+
+        private LogMatcher(String[] expectedMessages) {
+            this.expectedMessages = expectedMessages;
+        }
+
+        static LogMatcher containsErrors(String... expectedMessages) {
+            return new LogMatcher(expectedMessages);
+        }
+
+        @Override
+        protected boolean matchesSafely(ErrorLog errorLog, Description description) {
+            String[] actualMessages = getActualMessages(errorLog);
+            if (Arrays.equals(expectedMessages, actualMessages)) return true;
+
+            description.appendValueList("[", ",", "]", actualMessages);
+            return false;
+        }
+
+        private String[] getActualMessages(ErrorLog errorLog) {
+            try {
+                List<String> actualMessages = new ArrayList<>();
+                String line;
+                BufferedReader reader = new BufferedReader(new StringReader(errorLog.getErrors()));
+                while ((line = reader.readLine()) != null) actualMessages.add(line);
+                return actualMessages.toArray(new String[0]);
+            } catch (IOException e) {
+                return new String[0];
+            }
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendValueList("[", ",", "]", expectedMessages);
+        }
+    }
+}

--- a/src/test/java/io/prometheus/wls/rest/ExporterServletTest.java
+++ b/src/test/java/io/prometheus/wls/rest/ExporterServletTest.java
@@ -1,6 +1,6 @@
 package io.prometheus.wls.rest;
 /*
- * Copyright (c) 2017 Oracle and/or its affiliates
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
  */
@@ -123,7 +123,8 @@ public class ExporterServletTest {
         initServlet("");
 
         servlet.doGet(request, response);
-        assertThat(factory.getClientUrl(), equalTo(String.format(URL_PATTERN, HttpServletRequestStub.HOST, HttpServletRequestStub.PORT)));
+        assertThat(factory.getClientUrl(),
+                   equalTo(String.format(URL_PATTERN, LiveConfiguration.WLS_HOST, HttpServletRequestStub.PORT)));
     }
 
     @Test

--- a/src/test/java/io/prometheus/wls/rest/LiveConfigurationTest.java
+++ b/src/test/java/io/prometheus/wls/rest/LiveConfigurationTest.java
@@ -1,9 +1,10 @@
 package io.prometheus.wls.rest;
 /*
- * Copyright (c) 2017 Oracle and/or its affiliates
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
  */
+
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
 import io.prometheus.wls.rest.domain.ExporterConfig;
@@ -12,6 +13,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 import static io.prometheus.wls.rest.InMemoryFileSystem.withNoParams;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -70,13 +73,13 @@ public class LiveConfigurationTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         InMemoryFileSystem.uninstall();
         ConfigurationUpdaterStub.uninstall();
     }
 
     @Test
-    public void afterInitCalled_haveQueries() throws Exception {
+    public void afterInitCalled_haveQueries() {
         init(CONFIGURATION);
 
         assertThat(LiveConfiguration.hasQueries(), is(true));
@@ -88,19 +91,19 @@ public class LiveConfigurationTest {
     }
 
     @Test
-    public void whenInitNotCalled_haveNoQueries() throws Exception {
+    public void whenInitNotCalled_haveNoQueries() {
         assertThat(LiveConfiguration.hasQueries(), is(false));
     }
 
     @Test
-    public void afterInitCalled_haveExpectedConfiguration() throws Exception {
+    public void afterInitCalled_haveExpectedConfiguration() {
         init(CONFIGURATION);
 
         assertThat(LiveConfiguration.asString(), equalTo(CONFIGURATION));
     }
 
     @Test
-    public void afterInitCalledTwice_haveFirstConfiguration() throws Exception {
+    public void afterInitCalledTwice_haveFirstConfiguration() {
         init(CONFIGURATION);
         init(ADDED_CONFIGURATION);
 
@@ -108,7 +111,15 @@ public class LiveConfigurationTest {
     }
 
     @Test
-    public void afterInitTimestampIsZero() throws Exception {
+    public void afterServerDefined_queryUrlUsesLocalHost() throws MalformedURLException {
+        init(CONFIGURATION);
+        LiveConfiguration.setServer("fakeHost", 800);
+
+        assertThat(new URL(LiveConfiguration.getQueryUrl()).getHost(), equalTo("localhost"));
+    }
+
+    @Test
+    public void afterInitTimestampIsZero() {
         init(CONFIGURATION);
         
         assertThat(LiveConfiguration.getTimestamp(), equalTo(0L));
@@ -123,6 +134,7 @@ public class LiveConfigurationTest {
         assertThat(LiveConfiguration.asString(), equalTo(ADDED_CONFIGURATION));
     }
 
+    @SuppressWarnings("SameParameterValue")
     private ExporterConfig toConfiguration(String configuration) {
         return ExporterConfig.loadConfig(new ByteArrayInputStream(configuration.getBytes()));
     }
@@ -175,7 +187,7 @@ public class LiveConfigurationTest {
     }
 
     @Test
-    public void whenSharedTimestampIndicatesNewConfiguration_updateLiveConfiguration() throws Exception {
+    public void whenSharedTimestampIndicatesNewConfiguration_updateLiveConfiguration() {
         init(CONFIGURATION);
 
         long newTimestamp = LiveConfiguration.getTimestamp() + 1;
@@ -188,7 +200,7 @@ public class LiveConfigurationTest {
     }
 
     @Test
-    public void whenSharedTimestampIndicatesHaveLatestConfiguration_dontUpdateLiveConfiguration() throws Exception {
+    public void whenSharedTimestampIndicatesHaveLatestConfiguration_dontUpdateLiveConfiguration() {
         init(CONFIGURATION);
 
         long newTimestamp = LiveConfiguration.getTimestamp();

--- a/src/test/java/io/prometheus/wls/rest/LogServletTest.java
+++ b/src/test/java/io/prometheus/wls/rest/LogServletTest.java
@@ -1,0 +1,75 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package io.prometheus.wls.rest;
+
+import com.meterware.simplestub.Memento;
+import com.meterware.simplestub.StaticStubSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+public class LogServletTest {
+
+    private LogServlet servlet = new LogServlet();
+    private HttpServletRequestStub request = HttpServletRequestStub.createGetRequest();
+    private HttpServletResponseStub response = HttpServletResponseStub.createServletResponse();
+    private List<Memento> mementos = new ArrayList<>();
+
+    @Before
+    public void setUp() throws Exception {
+        InMemoryFileSystem.install();
+        LiveConfiguration.loadFromString("");
+    }
+
+    @After
+    public void tearDown() {
+        mementos.forEach(Memento::revert);
+    }
+
+    @Test
+    public void landingPage_isHttpServlet() {
+        assertThat(servlet, instanceOf(HttpServlet.class));
+    }
+
+    @Test
+    public void servlet_hasWebServletAnnotation() {
+        assertThat(LogServlet.class.getAnnotation(WebServlet.class), notNullValue());
+    }
+
+    @Test
+    public void servletAnnotationIndicatesMainPage() {
+        WebServlet annotation = LogServlet.class.getAnnotation(WebServlet.class);
+
+        assertThat(annotation.value(), arrayContaining("/log"));
+    }
+
+    @Test
+    public void whenNoErrorsReported_saySo() throws ServletException, IOException {
+        servlet.doGet(request, response);
+
+        assertThat(response.getHtml(), containsString("No errors reported."));
+    }
+
+    @Test
+    public void whenErrorsReported_listThem() throws NoSuchFieldException, ServletException, IOException {
+        ErrorLog errorLog = new ErrorLog();
+        mementos.add(StaticStubSupport.install(LiveConfiguration.class, "errorLog", errorLog));
+
+        errorLog.log(new WebClientException("Unable to reach server"));
+        servlet.doGet(request, response);
+
+        assertThat(response.getHtml(), containsString("WebClientException: Unable to reach server"));
+    }
+}

--- a/src/test/java/io/prometheus/wls/rest/WebClientFactoryStub.java
+++ b/src/test/java/io/prometheus/wls/rest/WebClientFactoryStub.java
@@ -1,11 +1,9 @@
 package io.prometheus.wls.rest;
 /*
- * Copyright (c) 2017 Oracle and/or its affiliates
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
  */
-
-import java.io.IOException;
 
 import static com.meterware.simplestub.Stub.createStrictStub;
 
@@ -57,7 +55,8 @@ abstract class WebClientFactoryStub implements WebClientFactory {
         }
 
         @Override
-        String doPutRequest(String putBody) throws IOException {
+        String doPutRequest(String putBody) {
+            if (exception != null) throw exception;
             postedValue = putBody;
             return null;
         }


### PR DESCRIPTION
With this change, the exporter always uses "localhost" to access the REST API, no matter what is found in the Host header. 