### PR TITLE
use InetAddress.getLocalHost to contact WLS

### DIFF
--- a/src/main/java/io/prometheus/wls/rest/LiveConfiguration.java
+++ b/src/main/java/io/prometheus/wls/rest/LiveConfiguration.java
@@ -16,6 +16,8 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Map;
 
 /**
@@ -28,7 +30,7 @@ class LiveConfiguration {
     static final String CONFIG_YML = "/config.yml";
 
     /** The address used to access WLS (cannot use the address found in the request due to potential server-side request forgery. */
-    static final String WLS_HOST = "localhost";
+    static final String WLS_HOST;
     
     private static final String URL_PATTERN = "http://%s:%d/management/weblogic/latest/serverRuntime/search";
     private static ExporterConfig config;
@@ -39,6 +41,15 @@ class LiveConfiguration {
 
     static {
         loadFromString("");
+        WLS_HOST = getLocalHostName();
+    }
+
+    private static String getLocalHostName() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            return "localhost";
+        }
     }
 
     private static Long timestamp;

--- a/src/test/java/io/prometheus/wls/rest/LiveConfigurationTest.java
+++ b/src/test/java/io/prometheus/wls/rest/LiveConfigurationTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
+import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -113,12 +114,13 @@ public class LiveConfigurationTest {
     }
 
     @Test
-    public void afterServerDefined_queryUrlUsesLocalHost() throws MalformedURLException {
+    public void afterServerDefined_queryUrlUsesLocalHost() throws Exception {
         init(CONFIGURATION);
         LiveConfiguration.setServer("fakeHost", 800);
         MBeanSelector selector = MBeanSelector.create(ImmutableMap.of());
 
-        assertThat(new URL(LiveConfiguration.getUrl(selector)).getHost(), equalTo("localhost"));
+        assertThat(new URL(LiveConfiguration.getUrl(selector)).getHost(),
+                   equalTo(InetAddress.getLocalHost().getHostName()));
     }
 
     @Test


### PR DESCRIPTION
It turns out that "localhost" is not a reliable way to reach a node in k8s, so this works better.