### PR TITLE
Provide good error message if default port does not reach REST api

### DIFF
--- a/src/main/java/io/prometheus/wls/rest/PassThroughAuthenticationServlet.java
+++ b/src/main/java/io/prometheus/wls/rest/PassThroughAuthenticationServlet.java
@@ -73,7 +73,7 @@ abstract public class PassThroughAuthenticationServlet extends HttpServlet {
             resp.setHeader("WWW-Authenticate", e.getChallenge());
             resp.sendError(SC_UNAUTHORIZED, "Authentication required");
         } catch (RestPortConnectionException e) {
-            resp.sendError(SC_INTERNAL_SERVER_ERROR, "Unable to reach REST API");
+            resp.setStatus(SC_INTERNAL_SERVER_ERROR);
             reportUnableToContactRestApi(resp, e.getUri());
         } finally {
             final HttpSession session = req.getSession(false);

--- a/src/main/java/io/prometheus/wls/rest/PassThroughAuthenticationServlet.java
+++ b/src/main/java/io/prometheus/wls/rest/PassThroughAuthenticationServlet.java
@@ -85,11 +85,11 @@ abstract public class PassThroughAuthenticationServlet extends HttpServlet {
         try (ServletOutputStream out = resp.getOutputStream()) {
             out.println("# Unable to contact the REST API at " + uri + ". May be using the wrong port.");
             out.println("#");
-            out.println("# This most commonly occurs when the exporter is accessed via a load-balancer");
+            out.println("# This most commonly occurs when the exporter is accessed via a load balancer");
             out.println("# configured on a different port than the managed server.");
             out.println("#");
             out.println("# You can correct this by giving the exporter WAR an initial configuration with the");
-            out.println("# restPort field set to the managed server's plain-text port.");
+            out.println("# restPort field set to the managed server's plain text port.");
         }
     }
 

--- a/src/main/java/io/prometheus/wls/rest/RestPortConnectionException.java
+++ b/src/main/java/io/prometheus/wls/rest/RestPortConnectionException.java
@@ -1,0 +1,23 @@
+// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at
+// http://oss.oracle.com/licenses/upl.
+
+package io.prometheus.wls.rest;
+
+import org.apache.http.HttpHost;
+
+/**
+ * An exception indicating that the client could not connect to the REST port.
+ */
+class RestPortConnectionException extends WebClientException {
+
+    private final String uri;
+
+    RestPortConnectionException(HttpHost host) {
+        uri = host.toURI();
+    }
+
+    String getUri() {
+        return uri;
+    }
+}

--- a/src/main/java/io/prometheus/wls/rest/WebClientImpl.java
+++ b/src/main/java/io/prometheus/wls/rest/WebClientImpl.java
@@ -12,6 +12,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.conn.HttpHostConnectException;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -63,6 +64,8 @@ public class WebClientImpl extends WebClient {
     private String sendRequest(HttpRequestBase request) throws IOException {
         try (CloseableHttpClient httpClient = createHttpClient()) {
             return getReply(httpClient, request);
+        } catch (HttpHostConnectException e) {
+            throw new RestPortConnectionException(e.getHost());
         } catch (UnknownHostException | ConnectException e) {
             throw new WebClientException(e, "Unable to execute %s request to %s", request.getMethod(), request.getURI());
         }

--- a/src/test/java/io/prometheus/wls/rest/HttpServletResponseStub.java
+++ b/src/test/java/io/prometheus/wls/rest/HttpServletResponseStub.java
@@ -1,6 +1,6 @@
 package io.prometheus.wls.rest;
 /*
- * Copyright (c) 2017 Oracle and/or its affiliates
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
  */
@@ -39,12 +39,12 @@ abstract class HttpServletResponseStub implements HttpServletResponse {
     }
 
     @Override
-    public ServletOutputStream getOutputStream() throws IOException {
+    public ServletOutputStream getOutputStream() {
         return out;
     }
 
     @Override
-    public void sendError(int sc, String msg) throws IOException {
+    public void sendError(int sc, String msg) {
         status = sc;
         responseSent = true;
     }
@@ -55,7 +55,12 @@ abstract class HttpServletResponseStub implements HttpServletResponse {
     }
 
     @Override
-    public void sendRedirect(String location) throws IOException {
+    public void setStatus(int sc) {
+        status = sc;
+    }
+
+    @Override
+    public void sendRedirect(String location) {
         redirectLocation = location;
     }
 
@@ -78,7 +83,7 @@ abstract class HttpServletResponseStub implements HttpServletResponse {
 
     @Override
     public Collection<String> getHeaders(String name) {
-        return headers.containsKey(name) ? headers.get(name) : Collections.emptyList();
+        return headers.getOrDefault(name, Collections.emptyList());
     }
 
     abstract static class ServletOutputStreamStub extends ServletOutputStream {
@@ -86,7 +91,7 @@ abstract class HttpServletResponseStub implements HttpServletResponse {
         private String html;
 
         @Override
-        public void write(int b) throws IOException {
+        public void write(int b) {
             baos.write(b);
         }
 


### PR DESCRIPTION
We have had a fair number of users encounter 500 errors with stack traces when following our recommendations for setting up and testing the exporter with the operator. This change detects the issue and offers a more informative error message.