### PR TITLE
fix error when installing Prometheus chart with v8.15.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 sudo: false
 script: mvn clean verify

--- a/samples/kubernetes/end2end/prometheus/values.yaml
+++ b/samples/kubernetes/end2end/prometheus/values.yaml
@@ -15,6 +15,9 @@ alertmanager:
   service:
     type: NodePort
     nodePort: 32000
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
 
 server:
   persistentVolume:
@@ -22,6 +25,9 @@ server:
   service:
     type: NodePort
     nodePort: 30000
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
 
 alertmanagerFiles:
   alertmanager.yml:


### PR DESCRIPTION
Fix to #53.

In latest Prometheus chart which is v8.15.0, it changed the default behavior to use user `nobody` to run containers and it's for running Prometheus in a k8s-cluster with a pod-security-policy disallowing running containers as root.  To make it work in this way, the PV folders need to set proper permission.

But in the end2end sample, we have other apps running on k8s, e.g. Grafana, MYSQL server, which are not ready to run in a k8s-cluster disallowing running containers as root.  So in my PR I change the Prometheus chart to the old behavior: use user root to run containers to get rid of the error.   

In the future when it's ready to run this sample in a k8s-cluster disallowing running containers as root, we can add additional step to set proper permission of PV folders.