### PR TITLE
Allow metrics to be retrieved from an SSL uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ query_sync:
 metricsNameSnakeCase: true
 domainQualifier: true
 restPort: 7001
+restProtocol: http
 queries:
 - key: name
   keyName: server
@@ -58,6 +59,7 @@ Note that there are two parts to the configuration. The optional top portion def
 | `metricsNameSnakeCase` | If true, metrics names will be converted to snake case. Defaults to false. |
 | `domainQualifier` | If true, the domain name will be included as a qualifier for all metrics. Defaults to false. |
 | `restPort` | Optional. Overrides the port on which the exporter should contact the REST API. Needed when behind a load balancer. |
+| `restProtocol` | Optional. Overrides the protocol with which the exporter should contact the REST API. Needed when API is exposed over https. |
 
 The `query` field is more complex. Each query consists of a hierarchy of the [MBeans](https://docs.oracle.com/middleware/1221/wls/WLMBR/core/index.html), starting relative to `ServerRuntimes`.
 Within each section, there are a number of options:

--- a/src/main/java/io/prometheus/wls/rest/LiveConfiguration.java
+++ b/src/main/java/io/prometheus/wls/rest/LiveConfiguration.java
@@ -33,12 +33,11 @@ class LiveConfiguration {
     /** The address used to access WLS (cannot use the address found in the request due to potential server-side request forgery. */
     static final String WLS_HOST;
 
-    static final String DEFAULT_REST_PROTOCOL = "http";
-
-    private static final String URL_PATTERN = "http://%s:%d/management/weblogic/latest/serverRuntime/search";
+    private static final String URL_PATTERN = "%s://%s:%d/management/weblogic/latest/serverRuntime/search";
     private static ExporterConfig config;
     private static String serverName;
     private static int serverPort;
+    private static String serverProtocol;
     private static ConfigurationUpdater updater = new NullConfigurationUpdater();
     private static ErrorLog errorLog = new ErrorLog();
 
@@ -74,7 +73,8 @@ class LiveConfiguration {
      * @param serverName the name of the server
      * @param serverPort the port on which the server is listening
      */
-    static void setServer(String serverName, int serverPort) {
+    static void setServer(String serverProtocol, String serverName, int serverPort) {
+        LiveConfiguration.serverProtocol = serverProtocol;
         LiveConfiguration.serverName = serverName;
         LiveConfiguration.serverPort = serverPort;
     }
@@ -84,7 +84,7 @@ class LiveConfiguration {
      * @return a url built for the configured server
      */
     static String getAuthenticationUrl() {
-        return String.format(URL_PATTERN, WLS_HOST, getRestPort());
+        return String.format(URL_PATTERN, getRestProtocol(), WLS_HOST, getRestPort());
     }
 
     /**
@@ -97,7 +97,7 @@ class LiveConfiguration {
     }
 
     private static String getRestProtocol() {
-        return Optional.ofNullable(config.getRestProtocol()).orElse(DEFAULT_REST_PROTOCOL);
+        return Optional.ofNullable(config.getRestProtocol()).orElse(serverProtocol);
     }
 
     private static int getRestPort() {

--- a/src/main/java/io/prometheus/wls/rest/LiveConfiguration.java
+++ b/src/main/java/io/prometheus/wls/rest/LiveConfiguration.java
@@ -32,7 +32,9 @@ class LiveConfiguration {
 
     /** The address used to access WLS (cannot use the address found in the request due to potential server-side request forgery. */
     static final String WLS_HOST;
-    
+
+    static final String DEFAULT_REST_PROTOCOL = "http";
+
     private static final String URL_PATTERN = "http://%s:%d/management/weblogic/latest/serverRuntime/search";
     private static ExporterConfig config;
     private static String serverName;
@@ -91,7 +93,11 @@ class LiveConfiguration {
      * @return a url built for the configured server
      */
     static String getUrl(MBeanSelector selector) {
-        return selector.getUrl(WLS_HOST, getRestPort());
+        return selector.getUrl(getRestProtocol(), WLS_HOST, getRestPort());
+    }
+
+    private static String getRestProtocol() {
+        return Optional.ofNullable(config.getRestProtocol()).orElse(DEFAULT_REST_PROTOCOL);
     }
 
     private static int getRestPort() {

--- a/src/main/java/io/prometheus/wls/rest/MainServlet.java
+++ b/src/main/java/io/prometheus/wls/rest/MainServlet.java
@@ -30,7 +30,7 @@ public class MainServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        LiveConfiguration.setServer(req.getServerName(), req.getServerPort());
+        LiveConfiguration.setServer(req.getScheme(), req.getServerName(), req.getServerPort());
         LiveConfiguration.updateConfiguration();
         resp.getOutputStream().println(ServletConstants.PAGE_HEADER);
         displayMetricsLink(req, resp.getOutputStream());

--- a/src/main/java/io/prometheus/wls/rest/PassThroughAuthenticationServlet.java
+++ b/src/main/java/io/prometheus/wls/rest/PassThroughAuthenticationServlet.java
@@ -28,7 +28,7 @@ abstract public class PassThroughAuthenticationServlet extends HttpServlet {
     }
 
     private WebClient createWebClient(HttpServletRequest req) {
-        LiveConfiguration.setServer(req.getServerName(), req.getServerPort());
+        LiveConfiguration.setServer(req.getScheme(), req.getServerName(), req.getServerPort());
         final WebClient webClient = webClientFactory.createClient();
         webClient.addHeader("X-Requested-By", "rest-exporter");
 

--- a/src/main/java/io/prometheus/wls/rest/domain/ExporterConfig.java
+++ b/src/main/java/io/prometheus/wls/rest/domain/ExporterConfig.java
@@ -22,6 +22,7 @@ public class ExporterConfig {
     static final String SNAKE_CASE = "metricsNameSnakeCase";
     static final String DOMAIN_QUALIFIER = "domainQualifier";
     static final String REST_PORT = "restPort";
+    static final String REST_PROTOCOL = "restProtocol";
     private static final String QUERIES = "queries";
     private static final String HOST = "host";
     private static final String PORT = "port";
@@ -36,6 +37,7 @@ public class ExporterConfig {
     private String host = DEFAULT_HOST;
     private int port = DEFAULT_PORT;
     private Integer restPort;
+    private String restProtocol;
     private boolean metricsNameSnakeCase;
     private QuerySyncConfiguration querySyncConfiguration;
     private boolean useDomainQualifier;
@@ -134,6 +136,7 @@ public class ExporterConfig {
         if (yaml.containsKey(HOST)) host = MapUtils.getStringValue(yaml, HOST);
         if (yaml.containsKey(PORT)) port = MapUtils.getIntegerValue(yaml, PORT);
         if (yaml.containsKey(REST_PORT)) restPort = MapUtils.getIntegerValue(yaml, REST_PORT);
+        if (yaml.containsKey(REST_PROTOCOL)) restProtocol = MapUtils.getStringValue(yaml, REST_PROTOCOL);
         if (yaml.containsKey(QUERY_SYNC)) querySyncConfiguration = loadQuerySync(yaml.get(QUERY_SYNC));
         if (yaml.containsKey(QUERIES)) appendQueries(asList(yaml.get(QUERIES)));
     }
@@ -243,6 +246,14 @@ public class ExporterConfig {
     }
 
     /**
+     * Returns the protocol with which the exporter will contact the REST API, if specified
+     * @return protocol string, or null
+     */
+    public String getRestProtocol() {
+        return restProtocol;
+    }
+
+    /**
      * Returns true if attribute names should be converted to snake case as metric names
      * @return true if the conversion should be done
      */
@@ -292,6 +303,7 @@ public class ExporterConfig {
         if (metricsNameSnakeCase) sb.append("metricsNameSnakeCase: true\n");
         if (useDomainQualifier) sb.append(DOMAIN_QUALIFIER + ": true\n");
         if (restPort != null) sb.append(REST_PORT + ": ").append(restPort).append("\n");
+        if (restProtocol != null) sb.append(REST_PROTOCOL + ": ").append(restProtocol).append("\n");
         sb.append("queries:\n");
 
         for (MBeanSelector query : getQueries())

--- a/src/main/java/io/prometheus/wls/rest/domain/MBeanSelector.java
+++ b/src/main/java/io/prometheus/wls/rest/domain/MBeanSelector.java
@@ -283,8 +283,8 @@ public class MBeanSelector {
         return nestedSelectors.get(selectorKey).mayMergeWith(other.nestedSelectors.get(selectorKey));
     }
 
-    public String getUrl(String myhost, int port) {
-        return String.format(queryType.getUrlPattern(), myhost, port);
+    public String getUrl(String protocol, String myhost, int port) {
+        return String.format(queryType.getUrlPattern(), protocol, myhost, port);
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/src/main/java/io/prometheus/wls/rest/domain/QueryType.java
+++ b/src/main/java/io/prometheus/wls/rest/domain/QueryType.java
@@ -44,12 +44,12 @@ public enum QueryType {
     /**
      * The pattern for a URL to which runtime REST queries are made.
      */
-    public static final String RUNTIME_URL_PATTERN = "http://%s:%d/management/weblogic/latest/serverRuntime/search";
+    public static final String RUNTIME_URL_PATTERN = "%s://%s:%d/management/weblogic/latest/serverRuntime/search";
 
     /**
      * The pattern for a URL to which configuration REST queries are made.
      */
-    public static final String CONFIGURATION_URL_PATTERN = "http://%s:%d/management/weblogic/latest/serverConfig/search";
+    public static final String CONFIGURATION_URL_PATTERN = "%s://%s:%d/management/weblogic/latest/serverConfig/search";
     static final String DOMAIN_KEY = "domainName";
 
     /**

--- a/src/test/java/io/prometheus/wls/rest/ConfigurationServletTest.java
+++ b/src/test/java/io/prometheus/wls/rest/ConfigurationServletTest.java
@@ -41,7 +41,7 @@ public class ConfigurationServletTest {
     @Before
     public void setUp() throws Exception {
         LiveConfiguration.loadFromString("");
-        LiveConfiguration.setServer(HttpServletRequestStub.HOST, HttpServletRequestStub.PORT);
+        LiveConfiguration.setServer(HttpServletRequestStub.SCHEME, HttpServletRequestStub.HOST, HttpServletRequestStub.PORT);
         request = createUploadRequest(createEncodedForm("replace", CONFIGURATION));
     }
 

--- a/src/test/java/io/prometheus/wls/rest/ExporterServletTest.java
+++ b/src/test/java/io/prometheus/wls/rest/ExporterServletTest.java
@@ -80,7 +80,7 @@ public class ExporterServletTest {
         InMemoryFileSystem.install();
         ConfigurationUpdaterStub.install();
         LiveConfiguration.loadFromString("");
-        LiveConfiguration.setServer("localhost", 7001);
+        LiveConfiguration.setServer("http", "localhost", 7001);
         ExporterSession.cacheSession(null, null);
         MessagesServlet.clear();
     }

--- a/src/test/java/io/prometheus/wls/rest/HttpServletRequestStub.java
+++ b/src/test/java/io/prometheus/wls/rest/HttpServletRequestStub.java
@@ -25,6 +25,7 @@ import static com.meterware.simplestub.Stub.createStrictStub;
 abstract class HttpServletRequestStub implements HttpServletRequest {
     final static String HOST = "myhost";
     final static int PORT = 7654;
+    final static String SCHEME = "http";
 
     private final static String DEFAULT_CONTENT_TYPE = "application/x-www-form-urlencoded";
     private Map<String,String> headers = new HashMap<>();
@@ -78,6 +79,11 @@ abstract class HttpServletRequestStub implements HttpServletRequest {
     @Override
     public String getProtocol() {
         return "HTTP/1.1";
+    }
+
+    @Override
+    public String getScheme() {
+        return SCHEME;
     }
 
     @Override

--- a/src/test/java/io/prometheus/wls/rest/LiveConfigurationTest.java
+++ b/src/test/java/io/prometheus/wls/rest/LiveConfigurationTest.java
@@ -79,7 +79,7 @@ public class LiveConfigurationTest {
     public void setUp() throws Exception {
         InMemoryFileSystem.install();
         ConfigurationUpdaterStub.install();
-        LiveConfiguration.setServer("localhost", 7001);
+        LiveConfiguration.setServer("http", "localhost", 7001);
     }
 
     @After
@@ -130,7 +130,7 @@ public class LiveConfigurationTest {
     @Test
     public void afterServerDefined_queryUrlUsesLocalHost() throws Exception {
         init(CONFIGURATION);
-        LiveConfiguration.setServer("fakeHost", 800);
+        LiveConfiguration.setServer("http", "fakeHost", 800);
         MBeanSelector selector = MBeanSelector.create(ImmutableMap.of());
 
         assertThat(new URL(LiveConfiguration.getUrl(selector)).getHost(),
@@ -140,7 +140,7 @@ public class LiveConfigurationTest {
     @Test
     public void whenNoRestPortSpecified_queryUrlUsesRequestPort() throws Exception {
         init(CONFIGURATION);
-        LiveConfiguration.setServer("fakeHost", 800);
+        LiveConfiguration.setServer("http", "fakeHost", 800);
         MBeanSelector selector = MBeanSelector.create(ImmutableMap.of());
 
         assertThat(new URL(LiveConfiguration.getUrl(selector)).getPort(),
@@ -150,7 +150,7 @@ public class LiveConfigurationTest {
     @Test
     public void whenRestPortSpecified_queryUrlUsesRequestPort() throws Exception {
         init(LOAD_BALANCE_CONFIGURATION);
-        LiveConfiguration.setServer("fakeHost", 800);
+        LiveConfiguration.setServer("http", "fakeHost", 800);
         MBeanSelector selector = MBeanSelector.create(ImmutableMap.of());
 
         assertThat(new URL(LiveConfiguration.getUrl(selector)).getPort(),
@@ -160,7 +160,7 @@ public class LiveConfigurationTest {
     @Test
     public void whenNoRestPortSpecified_authenticationUrlUsesRequestPort() throws Exception {
         init(CONFIGURATION);
-        LiveConfiguration.setServer("fakeHost", 800);
+        LiveConfiguration.setServer("http","fakeHost", 800);
         MBeanSelector selector = MBeanSelector.create(ImmutableMap.of());
 
         assertThat(new URL(LiveConfiguration.getAuthenticationUrl()).getPort(), equalTo(800));
@@ -169,7 +169,7 @@ public class LiveConfigurationTest {
     @Test
     public void whenRestPortSpecified_authenticationUrlUsesRequestPort() throws Exception {
         init(LOAD_BALANCE_CONFIGURATION);
-        LiveConfiguration.setServer("fakeHost", 800);
+        LiveConfiguration.setServer("http","fakeHost", 800);
         MBeanSelector selector = MBeanSelector.create(ImmutableMap.of());
 
         assertThat(new URL(LiveConfiguration.getAuthenticationUrl()).getPort(), equalTo(7001));

--- a/src/test/java/io/prometheus/wls/rest/MetricsStreamTest.java
+++ b/src/test/java/io/prometheus/wls/rest/MetricsStreamTest.java
@@ -38,7 +38,7 @@ public class MetricsStreamTest {
     @Before
     public void setUp() throws NoSuchFieldException {
         initMetricsStream();
-        LiveConfiguration.setServer("localhost", 7001);
+        LiveConfiguration.setServer("http", "localhost", 7001);
         mementos.add(SystemPropertySupport.preserve(LINE_SEPARATOR));
         mementos.add(StaticStubSupport.preserve(System.class, "lineSeparator"));
     }

--- a/src/test/java/io/prometheus/wls/rest/domain/ExporterConfigTest.java
+++ b/src/test/java/io/prometheus/wls/rest/domain/ExporterConfigTest.java
@@ -79,8 +79,8 @@ public class ExporterConfigTest {
 
         MBeanSelector[] queries = config.getEffectiveQueries();
         assertThat(queries, arrayWithSize(1));
-        assertThat(queries[0].getUrl("myhost", 1234),
-                equalTo(String.format(QueryType.RUNTIME_URL_PATTERN, "myhost", 1234)));
+        assertThat(queries[0].getUrl("http", "myhost", 1234),
+                equalTo(String.format(QueryType.RUNTIME_URL_PATTERN, "http", "myhost", 1234)));
      }
 
     @Test
@@ -90,8 +90,8 @@ public class ExporterConfigTest {
         MBeanSelector[] queries = config.getEffectiveQueries();
         assertThat(queries, arrayWithSize(2));
         assertThat(queries[0], sameInstance(MBeanSelector.DOMAIN_NAME_SELECTOR));
-        assertThat(queries[1].getUrl("myhost", 1234),
-                equalTo(String.format(QueryType.RUNTIME_URL_PATTERN, "myhost", 1234)));
+        assertThat(queries[1].getUrl("http", "myhost", 1234),
+                equalTo(String.format(QueryType.RUNTIME_URL_PATTERN, "http", "myhost", 1234)));
      }
 
     @Test

--- a/src/test/java/io/prometheus/wls/rest/domain/MBeanSelectorTest.java
+++ b/src/test/java/io/prometheus/wls/rest/domain/MBeanSelectorTest.java
@@ -33,8 +33,8 @@ public class MBeanSelectorTest {
     public void byDefault_useRuntimeRestUrl() {
         MBeanSelector selector = MBeanSelector.create(ImmutableMap.of());
 
-        assertThat(selector.getUrl("myhost", 1234),
-                   equalTo(String.format(QueryType.RUNTIME_URL_PATTERN, "myhost", 1234)));
+        assertThat(selector.getUrl("http", "myhost", 1234),
+                   equalTo(String.format(QueryType.RUNTIME_URL_PATTERN, "http", "myhost", 1234)));
     }
 
     @Test
@@ -42,8 +42,8 @@ public class MBeanSelectorTest {
         MBeanSelector selector = MBeanSelector.create(ImmutableMap.of());
         selector.setQueryType(QueryType.CONFIGURATION);
 
-        assertThat(selector.getUrl("myhost", 1234),
-                   equalTo(String.format(QueryType.CONFIGURATION_URL_PATTERN, "myhost", 1234)));
+        assertThat(selector.getUrl("http", "myhost", 1234),
+                   equalTo(String.format(QueryType.CONFIGURATION_URL_PATTERN, "http", "myhost", 1234)));
     }
 
     @Test
@@ -320,8 +320,8 @@ public class MBeanSelectorTest {
 
     @Test
     public void domainNameSelector_selectsConfigurationUrl() {
-        assertThat(MBeanSelector.DOMAIN_NAME_SELECTOR.getUrl("myhost", 1234),
-                   equalTo(String.format(QueryType.CONFIGURATION_URL_PATTERN, "myhost", 1234)));
+        assertThat(MBeanSelector.DOMAIN_NAME_SELECTOR.getUrl("http", "myhost", 1234),
+                   equalTo(String.format(QueryType.CONFIGURATION_URL_PATTERN, "http", "myhost", 1234)));
     }
 
     @Test


### PR DESCRIPTION
Replaced the hardcoded URL patterns with a placeholder. The scheme can be specified through config or determined based on scheme of the exporter app. Similar to the restPort.