### PR TITLE
fixes race condition in messages queue

### DIFF
--- a/src/main/java/io/prometheus/wls/rest/MessagesServlet.java
+++ b/src/main/java/io/prometheus/wls/rest/MessagesServlet.java
@@ -1,4 +1,4 @@
-// Copyright 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2019, 2020 Oracle Corporation and/or its affiliates.  All rights reserved.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 
@@ -14,6 +14,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 import static io.prometheus.wls.rest.ServletConstants.MESSAGES_PAGE;
 
@@ -25,7 +26,7 @@ public class MessagesServlet extends HttpServlet {
     static final int MAX_EXCHANGES = 5;
     private static final String TEMPLATE = "REQUEST:%n%s%nREPLY:%n%s%n";
 
-    private static Queue<String> messages = new ArrayDeque<>();
+    private static Queue<String> messages = new ConcurrentLinkedDeque<>();
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {

--- a/src/main/java/io/prometheus/wls/rest/MessagesServlet.java
+++ b/src/main/java/io/prometheus/wls/rest/MessagesServlet.java
@@ -1,4 +1,4 @@
-// Copyright 2019, 2020 Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 


### PR DESCRIPTION
Fixes the following error that is caused by race condition in messages queue in MessagesServlet.java:

<Feb 10, 2020 6:46:11,197 PM UTC> <Error> <HTTP> <BEA-101017>
<[ServletContext@900188294[app:wls-exporter-soa module:wls-exporter.war
path:null spec-version:3.1]] Root cause of ServletException.
java.util.NoSuchElementException
        at java.util.ArrayDeque.removeFirst(ArrayDeque.java:285)
        at java.util.ArrayDeque.remove(ArrayDeque.java:452)
        at io.prometheus.wls.rest.MessagesServlet.addExchange(MessagesServlet.java:44)
        at io.prometheus.wls.rest.ExporterServlet.getMetrics(ExporterServlet.java:90)
        at io.prometheus.wls.rest.ExporterServlet.displayMetrics(ExporterServlet.java:67)
