### PR TITLE
Don't request domain name if we already have it

### DIFF
--- a/src/main/java/io/prometheus/wls/rest/domain/ExporterConfig.java
+++ b/src/main/java/io/prometheus/wls/rest/domain/ExporterConfig.java
@@ -1,16 +1,22 @@
 package io.prometheus.wls.rest.domain;
 /*
- * Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates. All rights reserved.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
  */
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import com.google.gson.JsonObject;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.scanner.ScannerException;
-
-import java.io.InputStream;
-import java.util.*;
-import java.util.stream.Stream;
 
 /**
  * This class represents the configuration for the exporter, created by parsing YAML.
@@ -115,7 +121,7 @@ public class ExporterConfig {
     }
 
     private Stream<MBeanSelector> withPossibleDomainNameQuery(Stream<MBeanSelector> stream) {
-        return useDomainQualifier ? Stream.concat(Stream.of(MBeanSelector.DOMAIN_NAME_SELECTOR), stream) : stream;
+        return useDomainQualifier() ? Stream.concat(Stream.of(MBeanSelector.DOMAIN_NAME_SELECTOR), stream) : stream;
     }
 
     public static ExporterConfig loadConfig(Map<String, Object> yamlConfig) {
@@ -219,10 +225,10 @@ public class ExporterConfig {
     }
 
     private boolean isArrayOfMaps(Object object) {
-        return List.class.isAssignableFrom(object.getClass()) && emptyOrContainsMaps((List) object);
+        return List.class.isAssignableFrom(object.getClass()) && emptyOrContainsMaps((List<?>) object);
     }
 
-    private boolean emptyOrContainsMaps(List list) {
+    private boolean emptyOrContainsMaps(List<?> list) {
         return list.isEmpty() || list.get(0) instanceof Map;
     }
 
@@ -255,7 +261,7 @@ public class ExporterConfig {
      * @return true if the qualifier should be added
      */
     boolean useDomainQualifier() {
-        return useDomainQualifier;
+        return useDomainQualifier && (domainName == null);
     }
 
     String getDomainName() {
@@ -281,6 +287,7 @@ public class ExporterConfig {
         this.useDomainQualifier = config2.useDomainQualifier;
         MBeanSelector[] newQueries = config2.getQueries();
         this.queries = Arrays.copyOf(newQueries, newQueries.length);
+        this.domainName = null;
     }
 
     @Override

--- a/src/main/java/io/prometheus/wls/rest/domain/ExporterConfig.java
+++ b/src/main/java/io/prometheus/wls/rest/domain/ExporterConfig.java
@@ -1,6 +1,6 @@
 package io.prometheus.wls.rest.domain;
 /*
- * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
  */

--- a/src/test/java/io/prometheus/wls/rest/WebClientImplTest.java
+++ b/src/test/java/io/prometheus/wls/rest/WebClientImplTest.java
@@ -1,25 +1,28 @@
 package io.prometheus.wls.rest;
 /*
- * Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates. All rights reserved.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
  */
-
-import com.google.common.base.Strings;
-import com.meterware.pseudoserver.HttpUserAgentTest;
-import com.meterware.pseudoserver.PseudoServlet;
-import com.meterware.pseudoserver.WebResource;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.net.SocketException;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.common.base.Strings;
+import com.meterware.pseudoserver.HttpUserAgentTest;
+import com.meterware.pseudoserver.PseudoServlet;
+import com.meterware.pseudoserver.WebResource;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
 import static io.prometheus.wls.rest.ServletConstants.AUTHENTICATION_HEADER;
 import static io.prometheus.wls.rest.ServletConstants.COOKIE_HEADER;
-import static javax.servlet.http.HttpServletResponse.*;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
@@ -31,7 +34,10 @@ public class WebClientImplTest extends HttpUserAgentTest {
     private static final char QUOTE = '"';
 
     /** A URL with a host guaranteed not to exist. */
-    private static final String UNDEFINED_HOST_URL = "http://mxyptlk/";
+    private static final String UNDEFINED_HOST_URL = "http://seriously-this-should-not-exist/";
+
+    /** A URL on a known host with a port on which no server is listening. */
+    private static final String UNDEFINED_PORT_URL = "http://localhost:59236";
 
     private WebClientFactory factory = new WebClientFactoryImpl();
 
@@ -46,6 +52,7 @@ public class WebClientImplTest extends HttpUserAgentTest {
         sentHeaders.clear();
     }
 
+    @Ignore("The client seems to find something on some platforms??")
     @Test(expected = WebClientException.class)
     public void whenUnableToReachHost_throwException() throws Exception {
         factory.createClient().withUrl(UNDEFINED_HOST_URL).doGetRequest();
@@ -53,7 +60,7 @@ public class WebClientImplTest extends HttpUserAgentTest {
 
     @Test(expected = WebClientException.class)
     public void whenUnableToReachServer_throwException() throws Exception {
-        factory.createClient().withUrl(UNDEFINED_HOST_URL).doGetRequest();
+        factory.createClient().withUrl(UNDEFINED_PORT_URL).doGetRequest();
     }
 
     @Test

--- a/src/test/java/io/prometheus/wls/rest/WebClientImplTest.java
+++ b/src/test/java/io/prometheus/wls/rest/WebClientImplTest.java
@@ -1,6 +1,6 @@
 package io.prometheus.wls.rest;
 /*
- * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
  */

--- a/src/test/java/io/prometheus/wls/rest/WebClientImplTest.java
+++ b/src/test/java/io/prometheus/wls/rest/WebClientImplTest.java
@@ -15,7 +15,6 @@ import com.meterware.pseudoserver.HttpUserAgentTest;
 import com.meterware.pseudoserver.PseudoServlet;
 import com.meterware.pseudoserver.WebResource;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static io.prometheus.wls.rest.ServletConstants.AUTHENTICATION_HEADER;
@@ -34,7 +33,7 @@ public class WebClientImplTest extends HttpUserAgentTest {
     private static final char QUOTE = '"';
 
     /** A URL with a host guaranteed not to exist. */
-    private static final String UNDEFINED_HOST_URL = "http://seriously-this-should-not-exist/";
+    private static final String UNDEFINED_HOST_URL = "http://undefined.invalid";
 
     /** A URL on a known host with a port on which no server is listening. */
     private static final String UNDEFINED_PORT_URL = "http://localhost:59236";
@@ -52,7 +51,6 @@ public class WebClientImplTest extends HttpUserAgentTest {
         sentHeaders.clear();
     }
 
-    @Ignore("The client seems to find something on some platforms??")
     @Test(expected = WebClientException.class)
     public void whenUnableToReachHost_throwException() throws Exception {
         factory.createClient().withUrl(UNDEFINED_HOST_URL).doGetRequest();

--- a/src/test/java/io/prometheus/wls/rest/domain/ExporterConfigTest.java
+++ b/src/test/java/io/prometheus/wls/rest/domain/ExporterConfigTest.java
@@ -1,6 +1,6 @@
 package io.prometheus.wls.rest.domain;
 /*
- * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
  */


### PR DESCRIPTION
Fixes #82 

The exporter was requesting the domain name on each view, and the logic that hid it was confused. We now only request it once, as it should not change while the server is running.