### PR TITLE
OWLS-77659 Prevent JsonSyntaxException when server returns 5xx status

### DIFF
--- a/src/main/java/io/prometheus/wls/rest/PassThroughAuthenticationServlet.java
+++ b/src/main/java/io/prometheus/wls/rest/PassThroughAuthenticationServlet.java
@@ -1,9 +1,7 @@
+// Copyright 2017, 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
 package io.prometheus.wls.rest;
-/*
- * Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
- *
- * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
- */
 
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
@@ -72,6 +70,8 @@ abstract public class PassThroughAuthenticationServlet extends HttpServlet {
         } catch (AuthenticationChallengeException e) {
             resp.setHeader("WWW-Authenticate", e.getChallenge());
             resp.sendError(SC_UNAUTHORIZED, "Authentication required");
+        } catch (ServerErrorException e) {
+            resp.sendError(e.getStatus());
         } catch (RestPortConnectionException e) {
             resp.setStatus(SC_INTERNAL_SERVER_ERROR);
             reportUnableToContactRestApi(resp, e.getUri());

--- a/src/main/java/io/prometheus/wls/rest/ServerErrorException.java
+++ b/src/main/java/io/prometheus/wls/rest/ServerErrorException.java
@@ -1,0 +1,20 @@
+// Copyright 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+package io.prometheus.wls.rest;
+
+/**
+ * An exception thrown when a 5xx status code is received from the server.
+ */
+public class ServerErrorException extends WebClientException {
+
+  final int status;
+
+  public ServerErrorException(int status) {
+    this.status = status;
+  }
+
+  public int getStatus() {
+    return status;
+  }
+}

--- a/src/main/java/io/prometheus/wls/rest/WebClientImpl.java
+++ b/src/main/java/io/prometheus/wls/rest/WebClientImpl.java
@@ -1,9 +1,7 @@
+// Copyright 2017, 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
 package io.prometheus.wls.rest;
-/*
- * Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
- *
- * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
- */
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -137,6 +135,13 @@ public class WebClientImpl extends WebClient {
                 throw createAuthenticationChallengeException(response);
             case SC_FORBIDDEN:
                 throw new ForbiddenException();
+            case SC_INTERNAL_SERVER_ERROR:
+            case SC_NOT_IMPLEMENTED:
+            case SC_BAD_GATEWAY:
+            case SC_SERVICE_UNAVAILABLE:
+            case SC_GATEWAY_TIMEOUT:
+            case SC_HTTP_VERSION_NOT_SUPPORTED:
+                throw new ServerErrorException(response.getStatusLine().getStatusCode());
             case SC_OK:
                 String setCookieHeader = extractSessionSetCookieHeader(response);
                 if (setCookieHeader != null) {

--- a/src/test/java/io/prometheus/wls/rest/WebClientImplTest.java
+++ b/src/test/java/io/prometheus/wls/rest/WebClientImplTest.java
@@ -12,20 +12,21 @@ import com.google.common.base.Strings;
 import com.meterware.pseudoserver.HttpUserAgentTest;
 import com.meterware.pseudoserver.PseudoServlet;
 import com.meterware.pseudoserver.WebResource;
+import org.junit.Before;
+import org.junit.Test;
+
 import static javax.servlet.http.HttpServletResponse.SC_BAD_GATEWAY;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static javax.servlet.http.HttpServletResponse.SC_GATEWAY_TIMEOUT;
 import static javax.servlet.http.HttpServletResponse.SC_HTTP_VERSION_NOT_SUPPORTED;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_IMPLEMENTED;
 import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
-import org.junit.Before;
-import org.junit.Test;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import static io.prometheus.wls.rest.ServletConstants.AUTHENTICATION_HEADER;
 import static io.prometheus.wls.rest.ServletConstants.COOKIE_HEADER;
-import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
-import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.junit.MatcherAssert.assertThat;


### PR DESCRIPTION
Resolves an issue where the JsonSyntaxException error occurred due to WebLogic returning 503 when server appears to be overloaded, but LiveConfiguration.scrapeMetrics was trying to parse the response as a Json.

Error:
```
<[ServletContext@798248333[app:wls-exporter-cluster module:wls-exporter.war path:null spec-version:3.1]] Root cause of ServletException.
com.google.gson.JsonSyntaxException: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 12 path $
        at com.google.gson.JsonParser.parse(JsonParser.java:65)
        at com.google.gson.JsonParser.parse(JsonParser.java:45)
        at io.prometheus.wls.rest.LiveConfiguration.toJsonObject(LiveConfiguration.java:187)
        at io.prometheus.wls.rest.LiveConfiguration.scrapeMetrics(LiveConfiguration.java:182)
        at io.prometheus.wls.rest.ExporterServlet.getMetrics(ExporterServlet.java:93)
        at io.prometheus.wls.rest.ExporterServlet.displayMetrics(ExporterServlet.java:67)
        at io.prometheus.wls.rest.ExporterServlet.printMetrics(ExporterServlet.java:61)
        at io.prometheus.wls.rest.ExporterServlet.displayMetrics(ExporterServlet.java:54)
        at io.prometheus.wls.rest.PassThroughAuthenticationServlet.doWithAuthentication(PassThroughAuthenticationServlet.java:68)
        at io.prometheus.wls.rest.ExporterServlet.doGet(ExporterServlet.java:44)
```

503 Response from WebLogic:

```
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Draft//EN">
<HTML>
<HEAD>
<TITLE>Error 503--Service Unavailable</TITLE>
</HEAD>
<BODY bgcolor="white">
<FONT FACE=Helvetica><BR CLEAR=all>
<TABLE border=0 cellspacing=5><TR><TD><BR CLEAR=all>
<FONT FACE="Helvetica" COLOR="black" SIZE="3"><H2>Error 503--Service
Unavailable</H2>
</FONT></TD></TR>
</TABLE>
<TABLE border=0 width=100% cellpadding=10><TR><TD VALIGN=top WIDTH=100%
BGCOLOR=white><FONT FACE="Courier New"><FONT FACE="Helvetica"
SIZE="3"><H3>From RFC 2068 <i>Hypertext Transfer Protocol --
HTTP/1.1</i>:</H3>
</FONT><FONT FACE="Helvetica" SIZE="3"><H4>10.5.4 503 Service
Unavailable</H4>
</FONT><P><FONT FACE="Courier New">The server is currently unable to handle
the request due to a temporary overloading or maintenance of the server. The
implication is that this is a temporary condition which will be alleviated
after some delay. If known, the length of the delay may be indicated in a
Retry-After header.  If no Retry-After is given, the client SHOULD handle the
response as it would for a 500 response.<blockquote>Note: The existence of
the 503 status code does not imply that a server must use it when becoming
overloaded. Some servers may wish to simply refuse the
connection.</blockquote></FONT></P>
</FONT></TD></TR>
</TABLE>

</BODY>
</HTML>
```