### PR TITLE
display exception message in displayMetrics method

### DIFF
--- a/src/main/java/io/prometheus/wls/rest/ExporterServlet.java
+++ b/src/main/java/io/prometheus/wls/rest/ExporterServlet.java
@@ -69,7 +69,9 @@ public class ExporterServlet extends PassThroughAuthenticationServlet {
                 sort(metrics).forEach(metricsStream::printMetric);
         } catch (RestQueryException e) {
             metricsStream.println(
-                  withCommentMarkers("REST service was unable to handle this query\n" + selector.getPrintableRequest()));
+                  withCommentMarkers("REST service was unable to handle this query\n"
+                      + "exception: " + e.getMessage() + '\n'
+                      + selector.getPrintableRequest()));
         }
     }
 

--- a/src/main/java/io/prometheus/wls/rest/ExporterServlet.java
+++ b/src/main/java/io/prometheus/wls/rest/ExporterServlet.java
@@ -70,8 +70,8 @@ public class ExporterServlet extends PassThroughAuthenticationServlet {
         } catch (RestQueryException e) {
             metricsStream.println(
                   withCommentMarkers("REST service was unable to handle this query\n"
-                      + "exception: " + e.getMessage() + '\n'
-                      + selector.getPrintableRequest()));
+                      + selector.getPrintableRequest() + '\n'
+                      + "exception: " + e.getMessage()));
         }
     }
 


### PR DESCRIPTION
Simple display of exception message in displayMetrics method. While logging exception to logfile might be overloading for server, printing to http output shouldn't take any noticeable resources and might be really helpful for debugging. Haven't tested exact behavior yet, but just an idea.

Motivation: currently wls-exporter does not reply or log any exception cause that might happen during display of metrics, which makes finding the cause of errors problematic.    
Issue #98 was quite painful.