### PR TITLE
Upgrade Guava in response to CVE-2018-10237 vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>[24.1.1,)</version>
+            <version>29.0-jre</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>[24.1.1,)</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Received report https://github.com/oracle/weblogic-monitoring-exporter/network/alert/pom.xml/com.google.guava:guava/open