### PR TITLE
If REST port not accessible, try failing over to local port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Note that there are two parts to the configuration. The optional top portion def
 | `query_sync.interval` | The interval, in seconds, at which the service will be queried. Defaults to 10. |
 | `metricsNameSnakeCase` | If true, metrics names will be converted to snake case. Defaults to false. |
 | `domainQualifier` | If true, the domain name will be included as a qualifier for all metrics. Defaults to false. |
-| `restPort` | Optional. Overrides the port on which the exporter should contact the REST API. Needed when behind a load balancer. |
+| `restPort` | Optional. Overrides the port on which the exporter should contact the REST API. Needed if the exporter cannot find the REST API. |
 
 The `query` field is more complex. Each query consists of a hierarchy of the [MBeans](https://docs.oracle.com/middleware/1221/wls/WLMBR/core/index.html), starting relative to `ServerRuntimes`.
 Within each section, there are a number of options:
@@ -134,4 +134,4 @@ include the `restPort` configuration to tell the exporter which port to use.
 
 ## Copyright
 
- Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
+ Copyright &copy; 2017, 2020, Oracle Corporation and/or its affiliates.

--- a/src/main/java/io/prometheus/wls/rest/ConfigurationServlet.java
+++ b/src/main/java/io/prometheus/wls/rest/ConfigurationServlet.java
@@ -48,12 +48,15 @@ public class ConfigurationServlet extends PassThroughAuthenticationServlet {
     }
 
     private void updateConfiguration(WebClient webClient, HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        authenticate(webClient.withUrl(LiveConfiguration.getAuthenticationUrl(getProtocol())));
         try {
+            authenticate(webClient.withUrl(getAuthenticationUrl()));
             if (!ServletFileUpload.isMultipartContent(req)) throw new ServletException("Must be a multi-part request");
 
             createPostAction(req).perform();
             reportUpdatedConfiguration(resp);
+        } catch (RestPortConnectionException e) {
+            reportFailure(e);
+            webClient.setRetryNeeded(true);
         } catch (ConfigurationException e) {
             reportUnableToUpdateConfiguration(req, resp.getOutputStream(), e);
         }

--- a/src/main/java/io/prometheus/wls/rest/ExporterServlet.java
+++ b/src/main/java/io/prometheus/wls/rest/ExporterServlet.java
@@ -6,6 +6,8 @@ package io.prometheus.wls.rest;
  */
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Map;
 import java.util.TreeMap;
 import javax.servlet.ServletConfig;
@@ -48,19 +50,23 @@ public class ExporterServlet extends PassThroughAuthenticationServlet {
     @SuppressWarnings("unused") // The req parameter is not used, but is required by 'doWithAuthentication'
     private void displayMetrics(WebClient webClient, HttpServletRequest req, HttpServletResponse resp) throws IOException {
         LiveConfiguration.updateConfiguration();
-        try (MetricsStream metricsStream = new MetricsStream(resp.getOutputStream())) {
+        try (MetricsStream metricsStream = new MetricsStream(req, resp.getOutputStream())) {
             if (!LiveConfiguration.hasQueries())
                 metricsStream.println("# No configuration defined.");
             else
                 printMetrics(webClient, metricsStream);
-
         }
     }
 
     private void printMetrics(WebClient webClient, MetricsStream metricsStream) throws IOException {
-        for (MBeanSelector selector : LiveConfiguration.getQueries())
-            displayMetrics(webClient, metricsStream, selector);
-        metricsStream.printPerformanceMetrics();
+        try {
+            for (MBeanSelector selector : LiveConfiguration.getQueries())
+                displayMetrics(webClient, metricsStream, selector);
+            metricsStream.printPerformanceMetrics();
+        } catch (RestPortConnectionException e) {
+            reportFailure(e);
+            webClient.setRetryNeeded(true);
+        }
     }
 
     private void displayMetrics(WebClient webClient, MetricsStream metricsStream, MBeanSelector selector) throws IOException {
@@ -73,7 +79,18 @@ public class ExporterServlet extends PassThroughAuthenticationServlet {
                   withCommentMarkers("REST service was unable to handle this query\n"
                       + selector.getPrintableRequest() + '\n'
                       + "exception: " + e.getMessage()));
+        }  catch (IOException | RuntimeException | Error e) {
+            MessagesServlet.addExchange(getQueryUrl(selector), selector.getRequest(), toStackTrace(e));
+            throw e;
         }
+    }
+
+    private String toStackTrace(Throwable e) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        e.printStackTrace(pw);
+        pw.close();
+        return sw.toString();
     }
 
     private String withCommentMarkers(String string) {
@@ -95,7 +112,7 @@ public class ExporterServlet extends PassThroughAuthenticationServlet {
     }
 
     private String requestMetrics(WebClient webClient, MBeanSelector selector) throws IOException {
-        String url = LiveConfiguration.getUrl(getProtocol(), selector);
+        String url = getQueryUrl(selector);
         String jsonResponse = webClient.withUrl(url).doPostRequest(selector.getRequest());
         MessagesServlet.addExchange(url, selector.getRequest(), jsonResponse);
         return jsonResponse;

--- a/src/main/java/io/prometheus/wls/rest/MainServlet.java
+++ b/src/main/java/io/prometheus/wls/rest/MainServlet.java
@@ -1,19 +1,22 @@
 package io.prometheus.wls.rest;
 /*
- * Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
  */
+import java.io.IOException;
+import java.io.PrintStream;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.PrintStream;
 
-import static io.prometheus.wls.rest.ServletConstants.*;
+import static io.prometheus.wls.rest.ServletConstants.APPEND_ACTION;
+import static io.prometheus.wls.rest.ServletConstants.CONFIGURATION_PAGE;
+import static io.prometheus.wls.rest.ServletConstants.EFFECT_OPTION;
+import static io.prometheus.wls.rest.ServletConstants.REPLACE_ACTION;
 
 /**
  * This servlet represents the 'landing page' for the exporter.
@@ -30,8 +33,8 @@ public class MainServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        LiveConfiguration.setServer(req.getServerName(), req.getServerPort());
         LiveConfiguration.updateConfiguration();
+        LiveConfiguration.setServer(req);
         resp.getOutputStream().println(ServletConstants.PAGE_HEADER);
         displayMetricsLink(req, resp.getOutputStream());
         displayForm(req, resp.getOutputStream());

--- a/src/main/java/io/prometheus/wls/rest/MessagesServlet.java
+++ b/src/main/java/io/prometheus/wls/rest/MessagesServlet.java
@@ -18,14 +18,14 @@ import javax.servlet.http.HttpServletResponse;
 import static io.prometheus.wls.rest.ServletConstants.MESSAGES_PAGE;
 
 /**
- * A collector of REST requests and replies, that can be viewed to diagnose problems.List<String
+ * A collector of REST requests and replies, that can be viewed to diagnose problems.
  */
 @WebServlet("/" + MESSAGES_PAGE)
 public class MessagesServlet extends HttpServlet {
     static final int MAX_EXCHANGES = 5;
     private static final String TEMPLATE = "REQUEST to %s:%n%s%nREPLY:%n%s%n";
 
-    private static Queue<String> messages = new ConcurrentLinkedDeque<>();
+    private static final Queue<String> messages = new ConcurrentLinkedDeque<>();
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {

--- a/src/main/java/io/prometheus/wls/rest/UrlBuilder.java
+++ b/src/main/java/io/prometheus/wls/rest/UrlBuilder.java
@@ -6,19 +6,19 @@
 
 package io.prometheus.wls.rest;
 
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
 import javax.servlet.http.HttpServletRequest;
 
 import io.prometheus.wls.rest.domain.Protocol;
 
 public class UrlBuilder {
 
-  private static final List<Integer> successes = new ArrayList<>();
+  private static final Set<Integer> successes = new ConcurrentSkipListSet<>();
 
   private final String host;
   private final Protocol protocol;

--- a/src/main/java/io/prometheus/wls/rest/UrlBuilder.java
+++ b/src/main/java/io/prometheus/wls/rest/UrlBuilder.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+ */
+
+package io.prometheus.wls.rest;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import javax.servlet.http.HttpServletRequest;
+
+import io.prometheus.wls.rest.domain.Protocol;
+
+public class UrlBuilder {
+
+  private static final List<Integer> successes = new ArrayList<>();
+
+  private final String host;
+  private final Protocol protocol;
+  private final Queue<Integer> ports = new PriorityQueue<>(new PreferSuccesses());
+  private int lastCandidate;
+
+  public UrlBuilder(HttpServletRequest request, Integer restPort) {
+    host = request.getLocalName();
+    protocol = Protocol.getProtocol(request);
+    Optional.ofNullable(restPort).ifPresent(ports::add);
+    addPortIfNotPresent(request.getLocalPort());
+  }
+
+  private void addPortIfNotPresent(int port) {
+    if (!ports.contains(port)) ports.add(port);
+  }
+
+  public static void clearHistory() {
+    successes.clear();
+  }
+
+  public String createUrl(String urlPattern) {
+    return protocol.format(urlPattern, host, selectPort());
+  }
+
+  private int selectPort() {
+    if (ports.isEmpty()) throw new WebClientException("No connection port is defined");
+
+    return lastCandidate = ports.peek();
+  }
+
+  // Informs the builder that the last URL it supplied worked
+  public void reportSuccess() {
+    successes.add(lastCandidate);
+  }
+
+  // Informs the builder that the last URL it supplied failed.
+  public void reportFailure(WebClientException connectionException) {
+    successes.clear();
+    ports.remove();
+    if (ports.isEmpty()) throw connectionException;
+  }
+
+  private static final int SELECT_FIRST = -1;
+  private static final int NO_PREFERENCE = 0;
+  private static final int SELECT_LAST = +1;
+  private static class PreferSuccesses implements Comparator<Integer> {
+
+    @Override
+    public int compare(Integer first, Integer last) {
+      if (wasSuccessful(first) == wasSuccessful(last)) {
+        return NO_PREFERENCE;
+      } else if (wasSuccessful(first)) {
+        return SELECT_FIRST;
+      } else {
+        return SELECT_LAST;
+      }
+    }
+  }
+
+  private static boolean wasSuccessful(Integer port) {
+    return successes.contains(port);
+  }
+}

--- a/src/main/java/io/prometheus/wls/rest/WebClient.java
+++ b/src/main/java/io/prometheus/wls/rest/WebClient.java
@@ -1,12 +1,12 @@
 package io.prometheus.wls.rest;
 /*
- * Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
  */
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Objects;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * A client for sending http requests.
@@ -17,6 +17,7 @@ abstract class WebClient {
 
     private String authentication;
     private String sessionCookie;
+    private boolean retryNeeded;
 
     /**
      * Defines the authentication header to be sent on every request.
@@ -71,6 +72,22 @@ abstract class WebClient {
         if (getSetCookieHeader() != null) {
             resp.setHeader("Set-Cookie", getSetCookieHeader());
             cacheSessionCookie();
+        }
+    }
+
+    void setRetryNeeded(boolean retryNeeded) {
+        this.retryNeeded = retryNeeded;
+    }
+
+    /**
+     * Returns true of the 'retry needed' flag was set. Rests the flag on exit.
+     * @return true if a retry was requested
+     */
+    boolean isRetryNeeded() {
+        try {
+            return retryNeeded;
+        } finally {
+            retryNeeded = false;
         }
     }
 

--- a/src/main/java/io/prometheus/wls/rest/domain/MBeanSelector.java
+++ b/src/main/java/io/prometheus/wls/rest/domain/MBeanSelector.java
@@ -287,6 +287,10 @@ public class MBeanSelector {
         return protocol.format(queryType.getUrlPattern(), host, port);
     }
 
+    public QueryType getQueryType() {
+        return queryType;
+    }
+
     @SuppressWarnings("SameParameterValue")
     void setQueryType(QueryType queryType) {
         this.queryType = queryType;

--- a/src/test/java/io/prometheus/wls/rest/HttpServletRequestStub.java
+++ b/src/test/java/io/prometheus/wls/rest/HttpServletRequestStub.java
@@ -25,6 +25,7 @@ import static com.meterware.simplestub.Stub.createStrictStub;
 abstract class HttpServletRequestStub implements HttpServletRequest {
     final static String HOST = "myhost";
     final static int PORT = 7654;
+    final static int LOCAL_PORT = 7631;
 
     private final static String DEFAULT_CONTENT_TYPE = "application/x-www-form-urlencoded";
     private final Map<String,String> headers = new HashMap<>();
@@ -36,6 +37,8 @@ abstract class HttpServletRequestStub implements HttpServletRequest {
     private String servletPath = "";
     private HttpSessionStub session;
     private boolean secure;
+    private String host = HOST;
+    private int port = PORT;
 
     static HttpServletRequestStub createGetRequest() {
         return createStrictStub(HttpServletRequestStub.class, "GET");
@@ -43,6 +46,16 @@ abstract class HttpServletRequestStub implements HttpServletRequest {
 
     static HttpServletRequestStub createPostRequest() {
         return createStrictStub(HttpServletRequestStub.class, "POST");
+    }
+
+    HttpServletRequestStub withHost(String host) {
+        this.host = host;
+        return this;
+    }
+
+    HttpServletRequestStub withPort(int port) {
+        this.port = port;
+        return this;
     }
 
     HttpServletRequestStub(String method) {
@@ -109,12 +122,22 @@ abstract class HttpServletRequestStub implements HttpServletRequest {
 
     @Override
     public String getServerName() {
-        return HOST;
+        return host;
     }
 
     @Override
     public int getServerPort() {
-        return PORT;
+        return port;
+    }
+
+    @Override
+    public String getLocalName() {
+        return "localhost";
+    }
+
+    @Override
+    public int getLocalPort() {
+        return LOCAL_PORT;
     }
 
     @Override

--- a/src/test/java/io/prometheus/wls/rest/LiveConfigurationTest.java
+++ b/src/test/java/io/prometheus/wls/rest/LiveConfigurationTest.java
@@ -6,21 +6,17 @@ package io.prometheus.wls.rest;
  */
 
 import java.io.ByteArrayInputStream;
-import java.net.InetAddress;
-import java.net.URL;
 
-import com.google.common.collect.ImmutableMap;
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
 import io.prometheus.wls.rest.domain.ExporterConfig;
-import io.prometheus.wls.rest.domain.MBeanSelector;
-import io.prometheus.wls.rest.domain.Protocol;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static io.prometheus.wls.rest.HttpServletRequestStub.HOST;
+import static io.prometheus.wls.rest.HttpServletRequestStub.PORT;
 import static io.prometheus.wls.rest.InMemoryFileSystem.withNoParams;
-import static io.prometheus.wls.rest.domain.Protocol.HTTP;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -32,33 +28,25 @@ import static org.hamcrest.Matchers.is;
  */
 public class LiveConfigurationTest {
     private static final String CONFIGURATION =
-            "host: localhost\n" +
-            "port: 7001\n" +
+            "host: " + HOST + "\n" +
+            "port: " + PORT + "\n" +
             "queries:\n" + "" +
             "- groups:\n" +
             "    prefix: new_\n" +
             "    key: name\n" +
             "    values: [sample1, sample2]\n";
 
-    private static final String LOAD_BALANCE_CONFIGURATION =
-            "restPort: 7001\n" +
-            "queries:\n" + "" +
-            "- groups:\n" +
-            "    prefix: new_\n" +
-            "    key: name\n" +
-            "    values: [sample1, sample2]\n";
-
-    private static final String ADDED_CONFIGURATION = 
-            "host: localhost\n" +
-            "port: 7001\n" +
+    private static final String ADDED_CONFIGURATION =
+            "host: " + HOST + "\n" +
+            "port: " + PORT + "\n" +
             "queries:\n" + "" +
             "- people:\n" +
             "    key: name\n" +
             "    values: [age, sex]\n";
 
     private static final String COMBINED_CONFIGURATION =
-            "host: localhost\n" +
-            "port: 7001\n" +
+            "host: " + HOST + "\n" +
+            "port: " + PORT + "\n" +
             "queries:\n" + "" +
             "- groups:\n" +
             "    prefix: new_\n" +
@@ -84,7 +72,7 @@ public class LiveConfigurationTest {
     public void setUp() throws Exception {
         InMemoryFileSystem.install();
         ConfigurationUpdaterStub.install();
-        LiveConfiguration.setServer("localhost", 7001);
+        LiveConfiguration.setServer(HttpServletRequestStub.createPostRequest());
     }
 
     @After
@@ -130,54 +118,6 @@ public class LiveConfigurationTest {
         init(ADDED_CONFIGURATION);
 
         assertThat(LiveConfiguration.asString(), equalTo(CONFIGURATION));
-    }
-
-    @Test
-    public void afterServerDefined_queryUrlUsesLocalHost() throws Exception {
-        init(CONFIGURATION);
-        LiveConfiguration.setServer("fakeHost", 800);
-        MBeanSelector selector = MBeanSelector.create(ImmutableMap.of());
-
-        assertThat(new URL(LiveConfiguration.getUrl(HTTP, selector)).getHost(),
-                   equalTo(InetAddress.getLocalHost().getHostName()));
-    }
-
-    @Test
-    public void whenNoRestPortSpecified_queryUrlUsesRequestPort() throws Exception {
-        init(CONFIGURATION);
-        LiveConfiguration.setServer("fakeHost", 800);
-        MBeanSelector selector = MBeanSelector.create(ImmutableMap.of());
-
-        assertThat(new URL(LiveConfiguration.getUrl(HTTP, selector)).getPort(),
-                   equalTo(800));
-    }
-
-    @Test
-    public void whenRestPortSpecified_queryUrlUsesRequestPort() throws Exception {
-        init(LOAD_BALANCE_CONFIGURATION);
-        LiveConfiguration.setServer("fakeHost", 800);
-        MBeanSelector selector = MBeanSelector.create(ImmutableMap.of());
-
-        assertThat(new URL(LiveConfiguration.getUrl(HTTP, selector)).getPort(),
-                   equalTo(7001));
-    }
-
-    @Test
-    public void whenNoRestPortSpecified_authenticationUrlUsesRequestPort() throws Exception {
-        init(CONFIGURATION);
-        LiveConfiguration.setServer("fakeHost", 800);
-        MBeanSelector selector = MBeanSelector.create(ImmutableMap.of());
-
-        assertThat(new URL(LiveConfiguration.getAuthenticationUrl(Protocol.HTTP)).getPort(), equalTo(800));
-    }
-
-    @Test
-    public void whenRestPortSpecified_authenticationUrlUsesRequestPort() throws Exception {
-        init(LOAD_BALANCE_CONFIGURATION);
-        LiveConfiguration.setServer("fakeHost", 800);
-        MBeanSelector selector = MBeanSelector.create(ImmutableMap.of());
-
-        assertThat(new URL(LiveConfiguration.getAuthenticationUrl(Protocol.HTTP)).getPort(), equalTo(7001));
     }
 
     @Test

--- a/src/test/java/io/prometheus/wls/rest/MainServletTest.java
+++ b/src/test/java/io/prometheus/wls/rest/MainServletTest.java
@@ -1,19 +1,22 @@
 package io.prometheus.wls.rest;
 /*
- * Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
  */
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-
 import static io.prometheus.wls.rest.InMemoryFileSystem.withNoParams;
 import static io.prometheus.wls.rest.ServletConstants.CONFIGURATION_PAGE;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 /**
@@ -21,9 +24,9 @@ import static org.hamcrest.junit.MatcherAssert.assertThat;
  */
 public class MainServletTest {
 
-    private MainServlet servlet = new MainServlet();
-    private HttpServletRequestStub request = HttpServletRequestStub.createGetRequest();
-    private HttpServletResponseStub response = HttpServletResponseStub.createServletResponse();
+    private final MainServlet servlet = new MainServlet();
+    private final HttpServletRequestStub request = HttpServletRequestStub.createGetRequest();
+    private final HttpServletResponseStub response = HttpServletResponseStub.createServletResponse();
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/io/prometheus/wls/rest/UrlBuilderTest.java
+++ b/src/test/java/io/prometheus/wls/rest/UrlBuilderTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+ */
+
+package io.prometheus.wls.rest;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.http.HttpHost;
+import org.junit.Test;
+
+import static io.prometheus.wls.rest.HttpServletRequestStub.LOCAL_PORT;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+public class UrlBuilderTest {
+  private final static String URL_PATTERN = "%s://%s:%d/path";
+  private final static int REST_PORT = 7010;
+  private final HttpServletRequest request = HttpServletRequestStub.createGetRequest();
+  private final HttpHost httpHost = new HttpHost("localhost");
+  private final RestPortConnectionException connectionException = new RestPortConnectionException(httpHost);
+
+  @Test
+  public void whenNoRestPortDefined_generateUrl() {
+    UrlBuilder builder = new UrlBuilder(request, null);
+
+    assertThat(builder.createUrl(URL_PATTERN), equalTo(String.format(URL_PATTERN, "http", "localhost", LOCAL_PORT)));
+  }
+
+  @Test
+  public void whenRestPortDefined_generateUrlWithRestPort() {
+    UrlBuilder builder = new UrlBuilder(request, REST_PORT);
+
+    assertThat(builder.createUrl(URL_PATTERN), equalTo(String.format(URL_PATTERN, "http", "localhost", REST_PORT)));
+  }
+
+  @Test(expected = RestPortConnectionException.class)
+  public void whenNoRestPort_retryFails() {
+    UrlBuilder builder = new UrlBuilder(request, null);
+    builder.createUrl(URL_PATTERN);
+    
+    builder.reportFailure(connectionException);
+  }
+
+  @Test
+  public void afterRestPortFails_retryWithLocalPort() {
+    UrlBuilder builder = new UrlBuilder(request, REST_PORT);
+    builder.createUrl(URL_PATTERN);
+    builder.reportFailure(connectionException);
+
+    assertThat(builder.createUrl(URL_PATTERN), equalTo(String.format(URL_PATTERN, "http", "localhost", LOCAL_PORT)));
+  }
+
+  @Test(expected = RestPortConnectionException.class)
+  public void afterRestPortFails_secondRetryFails() {
+    UrlBuilder builder = new UrlBuilder(request, REST_PORT);
+    builder.createUrl(URL_PATTERN);
+    builder.reportFailure(connectionException);
+    builder.reportFailure(connectionException);
+
+    builder.createUrl(URL_PATTERN);
+  }
+
+  @Test
+  public void afterLocalPortSucceeds_newBuilderPrefersLocalPort() {
+    UrlBuilder builder = new UrlBuilder(request, REST_PORT);
+    builder.createUrl(URL_PATTERN);
+    builder.reportFailure(connectionException);
+    builder.createUrl(URL_PATTERN);
+    builder.reportSuccess();
+
+    UrlBuilder builder2 = new UrlBuilder(request, REST_PORT);
+    assertThat(builder2.createUrl(URL_PATTERN), equalTo(String.format(URL_PATTERN, "http", "localhost", LOCAL_PORT)));
+  }
+}

--- a/src/test/java/io/prometheus/wls/rest/WebClientFactoryStub.java
+++ b/src/test/java/io/prometheus/wls/rest/WebClientFactoryStub.java
@@ -1,41 +1,140 @@
 package io.prometheus.wls.rest;
 /*
- * Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
  */
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import org.apache.http.HttpHost;
+
 import static com.meterware.simplestub.Stub.createStrictStub;
 
-abstract class WebClientFactoryStub implements WebClientFactory {
-    private WebClientStub client = createStrictStub(WebClientStub.class);
+class WebClientFactoryStub implements WebClientFactory {
+    private final WebClientStub webClient = createStrictStub(WebClientStub.class);
 
     @Override
     public WebClient createClient() {
-        return client;
+        webClient.setRetryNeeded(false);
+        return webClient;
     }
 
-    void setException(WebClientException exception) {
-        client.exception = exception;
+    void addJsonResponse(Map<String, Object> responseMap) {
+        webClient.addJsonResponse(new Gson().toJson(responseMap));
     }
 
-    void setResponse(String response) {
-        client.response = response;
+    void addJsonResponse(String json) {
+        webClient.addJsonResponse(json);
+    }
+
+
+    void setSetCookieResponseHeader(String setCookieHeader) {
+        webClient.setCookieHeader = setCookieHeader;
+    }
+
+
+    String getSentQuery() {
+        return webClient.jsonQuery;
     }
 
     String getPostedString() {
-        return client.postedValue;
+        return webClient.postedString;
     }
 
-    String getClientURL() {
-        return client.url;
+    Map<String,String> getSentHeaders() {
+        return webClient.sentHeaders;
+    }
+
+    String getSentAuthentication() {
+        return webClient.getAuthentication();
+    }
+
+    String getSentSessionCookie() {
+        return webClient.getSessionCookie();
+    }
+
+    String getClientUrl() {
+        return webClient.url;
+    }
+
+    void reportNotAuthorized() {
+        webClient.reportForbidden();
+    }
+
+    void reportBadQuery() {
+        webClient.reportBadQuery();
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    void reportAuthenticationRequired(String basicRealmName) {
+        webClient.reportAuthenticationRequired(basicRealmName);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    void throwConnectionFailure(String host, int port) {
+        webClient.throwConnectionFailure(host, port);
+    }
+
+    void throwWebClientException(WebClientException e) {
+        webClient.addExceptionResponse(e);
     }
 
     static abstract class WebClientStub extends WebClient {
-        private WebClientException exception;
-        private String response;
-        private String postedValue;
+
         private String url;
+        private String jsonQuery;
+        private String setCookieHeader;
+        private final List<TestResponse> testResponses = new ArrayList<>();
+        private Iterator<TestResponse> responses;
+        private final Map<String, String> addedHeaders = new HashMap<>();
+        private Map<String, String> sentHeaders;
+        private String postedString;
+
+        private void addJsonResponse(String jsonResponse) {
+            addResponse(new JsonResponse(jsonResponse));
+        }
+
+        private void addResponse(TestResponse response) {
+            if (allResponsesHandled()) clearOldResponses();
+            testResponses.add(response);
+        }
+
+        private boolean allResponsesHandled() {
+            return responses != null && !responses.hasNext();
+        }
+
+        private void clearOldResponses() {
+            testResponses.clear();
+            responses = null;
+        }
+
+        void reportForbidden() {
+            addExceptionResponse(new ForbiddenException());
+        }
+
+        private void addExceptionResponse(WebClientException e) {
+            addResponse(new ExceptionResponse(e));
+        }
+
+        void reportBadQuery() {
+            addExceptionResponse(new RestQueryException());
+        }
+
+        @SuppressWarnings("SameParameterValue")
+        void reportAuthenticationRequired(String basicRealmName) {
+            addExceptionResponse(new AuthenticationChallengeException(String.format("Basic realm=\"%s\"", basicRealmName)));
+        }
+
+        void throwConnectionFailure(String host, int port) {
+            addExceptionResponse(new RestPortConnectionException(new HttpHost(host, port)));
+        }
 
         @Override
         WebClient withUrl(String url) {
@@ -45,27 +144,89 @@ abstract class WebClientFactoryStub implements WebClientFactory {
 
         @Override
         void addHeader(String name, String value) {
-            
+            addedHeaders.put(name, value);
         }
 
         @Override
-        String getSetCookieHeader() {
-            return null;
+        public String doPostRequest(String postBody) {
+            if (url == null) throw new NullPointerException("No URL specified");
+            sentHeaders = Collections.unmodifiableMap(addedHeaders);
+            this.jsonQuery = postBody;
+            if (setCookieHeader != null)
+                setSessionCookie(ExporterSession.getSessionCookie(setCookieHeader));
+
+            return getResult(getNextResponse());
         }
 
         @Override
         String doGetRequest() {
             if (url == null) throw new NullPointerException("No URL specified");
-            if (exception != null) throw exception;
-            return response;
+
+            return getResult(getNextResponse());
         }
 
         @Override
         String doPutRequest(String putBody) {
             if (url == null) throw new NullPointerException("No URL specified");
-            if (exception != null) throw exception;
-            postedValue = putBody;
+            postedString = putBody;
+
+            return getResult(getNextResponse());
+        }
+
+        private TestResponse getNextResponse() {
+            if (responses == null) responses = testResponses.iterator();
+            return !responses.hasNext() ? new JsonResponse(null) : responses.next();
+        }
+
+        private String getResult(TestResponse response) {
+            if (response.getException() != null) throw response.getException();
+            return response.getJsonResponse();
+        }
+
+        @Override
+        public String getSetCookieHeader() {
+            return setCookieHeader;
+        }
+    }
+
+    interface TestResponse {
+        WebClientException getException();
+        String getJsonResponse();
+    }
+
+    static class ExceptionResponse implements TestResponse {
+        private final WebClientException webClientException;
+
+        ExceptionResponse(WebClientException webClientException) {
+            this.webClientException = webClientException;
+        }
+
+        @Override
+        public WebClientException getException() {
+            return webClientException;
+        }
+
+        @Override
+        public String getJsonResponse() {
             return null;
+        }
+    }
+
+    static class JsonResponse implements TestResponse {
+        String jsonResponse;
+
+        JsonResponse(String jsonResponse) {
+            this.jsonResponse = jsonResponse;
+        }
+
+        @Override
+        public WebClientException getException() {
+            return null;
+        }
+
+        @Override
+        public String getJsonResponse() {
+            return jsonResponse;
         }
     }
 }


### PR DESCRIPTION
Replaces PR #115 

Fixes issues #101, #109, #110, #112 

Added several resiliency improvements, including:

- use local port rather than server port to access REST API
- use localhost by preference to access REST API
- if necessary, try both REST port and local port
- log exception in exporter servlet to messages servlet

