### PR TITLE
create JDK8-based WebClient implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <module>wls-exporter-core</module>
         <module>build-helper-mojo</module>
         <module>wls-exporter-war</module>
+        <module>wls-operator-exporter</module>
     </modules>
     <packaging>pom</packaging>
 
@@ -165,16 +166,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>build-operator-exporter</id>
-            <activation>
-                <jdk>[11,)</jdk>
-            </activation>
-            <modules>
-                <module>wls-operator-exporter</module>
-            </modules>
-        </profile>
-    </profiles>
 </project>

--- a/wls-exporter-core/pom.xml
+++ b/wls-exporter-core/pom.xml
@@ -76,9 +76,11 @@
     <profiles>
         <profile>
             <id>jdk11Client</id>
+<!--
             <activation>
                 <jdk>[11,)</jdk>
             </activation>
+-->
             <build>
                 <plugins>
                     <plugin>

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/ConfigurationServlet.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/ConfigurationServlet.java
@@ -61,7 +61,7 @@ public class ConfigurationServlet extends PassThroughAuthenticationServlet {
 
     // Authenticates by attempting to send a request to the Management RESTful API.
     private void authenticate(WebClient webClient) throws IOException {
-        webClient.doGetRequest();
+        webClient.doPostRequest("{ 'links':[], 'fields':[], 'children':{} }".replace("'", "\""));
     }
 
     private boolean isMultipartContent(HttpServletRequest request) {

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/ServletConstants.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/ServletConstants.java
@@ -28,6 +28,9 @@ public interface ServletConstants {
     /** The header used by a web client to send its authentication credentials. **/
     String AUTHENTICATION_HEADER = "Authorization";
 
+    /** The header used by a web client to specify the content type of its data. **/
+    String CONTENT_TYPE_HEADER = "Content-Type";
+
     /** The header used by a web client to send cookies as part of a request. */
     String COOKIE_HEADER = "Cookie";
 

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClient.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClient.java
@@ -14,6 +14,9 @@ import javax.servlet.http.HttpServletResponse;
  */
 public interface WebClient {
 
+  String APPLICATION_JSON = "application/json; charset=UTF-8";
+  String X_REQUESTED_BY_HEADER = "X-Requested-By";
+
   /**
    * Sets the url to which this client will send requests.
    * @param url a URL for requests

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClient.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClient.java
@@ -4,9 +4,6 @@
 package com.oracle.wls.exporter;
 
 import java.io.IOException;
-import java.util.List;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
@@ -23,8 +20,6 @@ public interface WebClient {
    * @return this instance
    */
   WebClient withUrl(String url);
-
-  List<MultipartItem> parse(HttpServletRequest request) throws ServletException;
 
   /**
    * Sends a plain GET request to the defined URL without parameters

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClient8Impl.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClient8Impl.java
@@ -16,6 +16,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+/**
+ * A stripped-down web client that uses classes built into Java 1.8.
+ */
 public class WebClient8Impl extends WebClientCommon {
 
   static class Header {

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClient8Impl.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClient8Impl.java
@@ -1,5 +1,5 @@
-// Copyright 2020 Oracle Corporation and/or its affiliates.
-// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
 

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClient8Impl.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClient8Impl.java
@@ -1,0 +1,190 @@
+// Copyright 2020 Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+package com.oracle.wls.exporter;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class WebClient8Impl extends WebClientCommon {
+
+  static class Header {
+    private String name;
+    private String value;
+
+    Header(String name, String value) {
+      this.name = name;
+      this.value = value;
+    }
+
+    void addHeader(HttpURLConnection connection) {
+      connection.setRequestProperty(name, value);
+    }
+  }
+
+  private final List<Header> defaultHeaders = new ArrayList<>();
+  private final List<Header> sessionHeaders = new ArrayList<>();
+
+  @Override
+  void clearSessionHeaders() {
+    sessionHeaders.clear();
+  }
+
+  @Override
+  void putSessionHeader(String key, String value) {
+    sessionHeaders.add(new Header(key, value));
+  }
+
+  @Override
+  HttpClientExec createClientExec() {
+    return new Java8HttpClientExec();
+  }
+
+  @Override
+  WebRequest createGetRequest(String url) {
+    return new Java8WebRequest("GET", url);
+  }
+
+  @Override
+  WebRequest createPostRequest(String url, String postBody) {
+    return new Java8WebRequestWithBody("POST", url, postBody);
+  }
+
+  @Override
+  WebRequest createPutRequest(String url, String putBody) {
+    return new Java8WebRequestWithBody("PUT", url, putBody);
+  }
+
+  @Override
+  public void addHeader(String name, String value) {
+    defaultHeaders.add(new Header(name, value));
+  }
+
+  class Java8WebRequest implements WebRequest {
+    private final String method;
+    private final String url;
+
+    Java8WebRequest(String method, String url) {
+      this.method = method;
+      this.url = url;
+    }
+
+    @Override
+    public String getMethod() {
+      return method;
+    }
+
+    @Override
+    public URI getURI() {
+      try {
+        return new URI(url);
+      } catch (URISyntaxException e) {
+        throw new WebClientException(e, "Unable parse URL %1", url);
+      }
+    }
+
+    public void completeRequest(HttpURLConnection connection) throws IOException {
+      defaultHeaders.forEach(h -> h.addHeader(connection));
+      sessionHeaders.forEach(h -> h.addHeader(connection));
+      connection.setRequestMethod(method);
+    }
+
+  }
+
+  class Java8WebRequestWithBody extends Java8WebRequest {
+    private final String body;
+
+    public Java8WebRequestWithBody(String method, String url, String body) {
+      super(method, url);
+      this.body = body;
+    }
+
+    @Override
+    public void completeRequest(HttpURLConnection connection) throws IOException {
+      super.completeRequest(connection);
+      connection.setDoOutput(true);
+      connection.getOutputStream().write(body.getBytes());
+    }
+  }
+
+  static class Java8WebResponse implements WebResponse {
+    private final WebRequest request;
+    private final HttpURLConnection connection;
+    private final int responseCode;
+    private final Map<String, List<String>> headerFields;
+
+    Java8WebResponse(WebRequest request, HttpURLConnection connection) throws IOException {
+      this.request = request;
+      this.connection = connection;
+      responseCode = connection.getResponseCode();
+      headerFields = connection.getHeaderFields();
+    }
+
+    @Override
+    public InputStream getContents() {
+      try {
+        return connection.getInputStream();
+      } catch (IOException e) {
+        throw new RestPortConnectionException(request.getURI().toString());
+      }
+    }
+
+    @Override
+    public int getResponseCode() {
+      return responseCode;
+    }
+
+    @Override
+    public Stream<String> getHeadersAsStream(String headerName) {
+      return Optional.ofNullable(headerFields.get(headerName)).map(Collection::stream).orElse(Stream.empty());
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+  }
+
+  static class Java8HttpClientExec implements HttpClientExec {
+    @Override
+    public WebResponse send(WebRequest request) throws IOException {
+      HttpURLConnection connection = openConnection(request.getURI().toURL());
+      ((Java8WebRequest) request).completeRequest(connection);
+
+      return new Java8WebResponse(request, connection);
+    }
+
+    /**
+     * open a connection for the given uniform resource locator
+     * @param url - the url to use
+     */
+    private HttpURLConnection openConnection(URL url ) throws IOException {
+      try {
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setInstanceFollowRedirects( true );
+        connection.setUseCaches( false );
+        return connection;
+      } catch (WebClientException e) {
+        if (e.getCause() instanceof IOException)
+          throw (IOException) e.getCause();
+        else
+          throw e;
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+  }
+}

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClient8Impl.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClient8Impl.java
@@ -135,7 +135,7 @@ public class WebClient8Impl extends WebClientCommon {
       try {
         return connection.getInputStream();
       } catch (IOException e) {
-        throw new RestPortConnectionException(request.getURI().toString());
+        return new EmptyInputStream();
       }
     }
 

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientCommon.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientCommon.java
@@ -128,7 +128,9 @@ abstract class WebClientCommon implements WebClient {
     private String sendRequest(WebRequest request) throws IOException {
         try (HttpClientExec clientExec = createClientExec()) {
             return getReply(clientExec.send(request));
-        } catch (UnknownHostException | ConnectException | GeneralSecurityException e) {
+        } catch (UnknownHostException | ConnectException e) {
+            throw new RestPortConnectionException(request.getURI().toString());
+        } catch (GeneralSecurityException e) {
             throw new WebClientException(e, "Unable to execute %s request to %s", request.getMethod(), request.getURI());
         }
     }

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientCommon.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientCommon.java
@@ -24,7 +24,7 @@ import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 /**
- * A client for sending http requests.
+ * A client for sending http requests.  Note that it does not do any cookie management or authentication by itself.
  *
  * @author Russell Gold
  */
@@ -52,6 +52,10 @@ abstract class WebClientCommon implements WebClient {
         WebResponse send(WebRequest request) throws IOException;
     }
 
+    /**
+     * Creates an instance for communications with a specific URL.
+     * @param url a URL for requests
+     */
     @Override
     public WebClientCommon withUrl(String url) {
         this.url = url;
@@ -100,10 +104,6 @@ abstract class WebClientCommon implements WebClient {
 
     protected String getContentType() {
         return contentType;
-    }
-
-    protected void setContentType(String contentType) {
-        this.contentType = contentType;
     }
 
     final String getUrl() {

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientFactoryImpl.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientFactoryImpl.java
@@ -13,8 +13,8 @@ import java.lang.reflect.InvocationTargetException;
  */
 public class WebClientFactoryImpl implements WebClientFactory {
 
-  static final String APACHE_BASED_CLIENT = "com.oracle.wls.exporter.WebClient11Impl";
-  static final String JDK_BASED_CLIENT = "com.oracle.wls.exporter.WebClientImpl";
+  static final String APACHE_BASED_CLIENT = "com.oracle.wls.exporter.WebClientImpl";
+  static final String JDK_BASED_CLIENT = "com.oracle.wls.exporter.WebClientImpl8";
   static final String[] CLIENT_CLASS_NAMES = {APACHE_BASED_CLIENT, JDK_BASED_CLIENT};
 
   static Constructor<? extends WebClient> clientConstructor;

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientImpl.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientImpl.java
@@ -11,16 +11,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -45,7 +38,9 @@ import org.apache.http.ssl.SSLContexts;
 import org.apache.http.ssl.TrustStrategy;
 
 /**
- * A production implementation of the web client interface that uses Apache HttpClient code.
+ * A production implementation of the web client interface that uses Apache HttpClient code. Since it is intended
+ * to invoke the WebLogic REST API from a web application on the same server, it does not do any enforcement
+ * of signed certificates when using https.
  *
  * @author Russell Gold
  */
@@ -62,15 +57,6 @@ public class WebClientImpl extends WebClientCommon {
     @Override
     protected HttpGetRequest createGetRequest(String url) {
         return new HttpGetRequest(url);
-    }
-
-    public static List<MultipartItem> doParse(HttpServletRequest request) throws ServletException {
-        try {
-            ServletFileUpload upload = new ServletFileUpload(new DiskFileItemFactory());
-            return upload.parseRequest(request).stream().map(ApacheMultipartItem::new).collect(Collectors.toList());
-        } catch (FileUploadException e) {
-            throw new ServletException("unable to parse post body", e);
-        }
     }
 
     static class HttpGetRequest extends HttpGet implements WebRequest {
@@ -102,34 +88,6 @@ public class WebClientImpl extends WebClientCommon {
     static class HttpPutRequest extends HttpPut implements WebRequest {
         public HttpPutRequest(String uri) {
             super(uri);
-        }
-    }
-
-    static class ApacheMultipartItem implements MultipartItem {
-        private final FileItem fileItem;
-
-        ApacheMultipartItem(FileItem fileItem) {
-            this.fileItem = fileItem;
-        }
-
-        @Override
-        public boolean isFormField() {
-            return fileItem.isFormField();
-        }
-
-        @Override
-        public String getFieldName() {
-            return fileItem.getFieldName();
-        }
-
-        @Override
-        public String getString() {
-            return fileItem.getString();
-        }
-
-        @Override
-        public InputStream getInputStream() throws IOException {
-            return fileItem.getInputStream();
         }
     }
 

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientImpl.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientImpl.java
@@ -73,11 +73,6 @@ public class WebClientImpl extends WebClientCommon {
         }
     }
 
-    @Override
-    public List<MultipartItem> parse(HttpServletRequest request) throws ServletException {
-        return doParse(request);
-    }
-
     static class HttpGetRequest extends HttpGet implements WebRequest {
         public HttpGetRequest(String uri) {
             super(uri);

--- a/wls-exporter-core/src/main/java11/com/oracle/wls/exporter/WebClient11Impl.java
+++ b/wls-exporter-core/src/main/java11/com/oracle/wls/exporter/WebClient11Impl.java
@@ -76,11 +76,6 @@ public class WebClient11Impl extends WebClientCommon {
     return new Java11HttpClientExec();
   }
 
-  @Override
-  public List<MultipartItem> parse(HttpServletRequest request) throws ServletException {
-    return MultipartContentParser.parse(request);
-  }
-
   class Java11WebRequest implements WebRequest {
 
     private final HttpRequest request;

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClient8ImplTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClient8ImplTest.java
@@ -1,0 +1,7 @@
+package com.oracle.wls.exporter;
+
+public class WebClient8ImplTest extends WebClientTestBase {
+  public WebClient8ImplTest() {
+    super(WebClient8Impl::new);
+  }
+}

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClient8ImplTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClient8ImplTest.java
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package com.oracle.wls.exporter;
 
 public class WebClient8ImplTest extends WebClientTestBase {

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClientFactoryImplTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClientFactoryImplTest.java
@@ -1,0 +1,49 @@
+// Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.wls.exporter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import com.meterware.simplestub.Memento;
+import com.meterware.simplestub.StaticStubSupport;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+public class WebClientFactoryImplTest {
+
+  private final List<Memento> mementos = new ArrayList<>();
+  private Function<String, Class<? extends WebClient>> apacheClassesMissing = WebClientFactoryImplTest::reportApacheClassesMissing;
+
+  static Class<? extends WebClient> reportApacheClassesMissing(String className) {
+    if (className.equals(WebClientImpl.class.getName()))
+      throw new NoClassDefFoundError("a class");
+    else if (className.equals(WebClient8Impl.class.getName()))
+      return WebClient8Impl.class;
+    else
+      throw new RuntimeException("Unexpected client class name: " + className);
+  }
+
+  @After
+  public void tearDown() {
+    mementos.forEach(Memento::revert);
+  }
+
+  @Test
+  public void whenApacheClientDependentClassesFound_selectApacheClient() {
+    assertThat(WebClientFactoryImpl.getClientConstructor().getDeclaringClass(), sameInstance(WebClientImpl.class));
+  }
+
+  @Test
+  public void whenApacheClientDependentClassesMissing_selectJKD8Client() throws NoSuchFieldException {
+    mementos.add(StaticStubSupport.install(WebClientFactoryImpl.class, "loadClientClass", apacheClassesMissing));
+
+    assertThat(WebClientFactoryImpl.getClientConstructor().getDeclaringClass(), sameInstance(WebClient8Impl.class));
+  }
+
+}

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClientFactoryStub.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClientFactoryStub.java
@@ -9,8 +9,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
 
 import com.google.gson.Gson;
 
@@ -187,10 +185,6 @@ class WebClientFactoryStub implements WebClientFactory {
             return setCookieHeader;
         }
 
-        @Override
-        public List<MultipartItem> parse(HttpServletRequest request) throws ServletException {
-            return MultipartContentParser.parse(request);
-        }
     }
 
     interface TestResponse {

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClientFactoryStub.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClientFactoryStub.java
@@ -84,6 +84,7 @@ class WebClientFactoryStub implements WebClientFactory {
     }
 
     static abstract class WebClientStub extends WebClientCommon {
+        private final String WLS_SEARCH_PATH = "/management/weblogic/latest/serverRuntime/search";
 
         private String url;
         private String jsonQuery;
@@ -158,6 +159,7 @@ class WebClientFactoryStub implements WebClientFactory {
         @Override
         public String doGetRequest() {
             if (url == null) throw new NullPointerException("No URL specified");
+            if (url.contains(WLS_SEARCH_PATH)) throw new AssertionError("GET to search paths is not supported");
 
             return getResult(getNextResponse());
         }

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClientTestBase.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClientTestBase.java
@@ -338,7 +338,7 @@ abstract class WebClientTestBase extends HttpUserAgentTest {
     }
 
     @Test(expected = RestPortConnectionException.class)
-    public void whenUnableToConnection_throwsException() throws IOException {
+    public void whenUnableToConnect_throwsException() throws IOException {
         testSupport.tearDownServer();
 
         for (int attempt = 0; attempt < 20; attempt++)


### PR DESCRIPTION
Implemented WebClient using HttpURLConnection, so that it is usable in JDK8, where most Weblogic images will presumably run under the operator.

Fixed the erroneous swapping of the Apache-based and JDK-based implementation names.