### PR TITLE
Prepare for 1.3.0 release

### DIFF
--- a/build-helper-mojo/pom.xml
+++ b/build-helper-mojo/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>wls-exporter-parent</artifactId>
         <groupId>com.oracle.wls.exporter</groupId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>build-helper-mojo</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.oracle.wls.exporter</groupId>
     <artifactId>wls-exporter-parent</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0</version>
     <modules>
         <module>wls-exporter-core</module>
         <module>build-helper-mojo</module>
@@ -21,12 +21,20 @@
     <name>WebLogic Monitoring Exporter</name>
     <description>A Prometheus exporter that takes advantage of WebLogic Server-specific features.</description>
 
+    <url>https://github.com/oracle/weblogic-monitoring-exporter</url>
+
     <licenses>
         <license>
             <name>Oracle Universal Permissive License, Version 1.0</name>
             <url>http://oss.oracle.com/licenses/upl</url>
         </license>
     </licenses>
+
+    <scm>
+        <url>https://github.com/oracle/weblogic-monitoring-exporter.git</url>
+        <developerConnection>scm:git:https://github.com/oracle/weblogic-monitoring-exporter.git</developerConnection>
+        <connection>scm:git:https://github.com/oracle/weblogic-monitoring-exporter.git</connection>
+    </scm>
 
     <developers>
         <developer>
@@ -38,6 +46,7 @@
     </developers>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <apache.http.version>4.5.3</apache.http.version>
     </properties>
 

--- a/wls-exporter-core/pom.xml
+++ b/wls-exporter-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>wls-exporter-parent</artifactId>
         <groupId>com.oracle.wls.exporter</groupId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>wls-exporter-core</artifactId>

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientCommon.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientCommon.java
@@ -142,7 +142,9 @@ abstract class WebClientCommon implements WebClient {
 
     private String getReply(WebResponse response) throws IOException {
         processStatusCode(response);
-        return toString(response.getContents());
+        try (final InputStream contents = response.getContents()) {
+            return toString(contents);
+        }
     }
 
     private void processStatusCode(WebResponse response) {

--- a/wls-exporter-war/pom.xml
+++ b/wls-exporter-war/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>wls-exporter-parent</artifactId>
         <groupId>com.oracle.wls.exporter</groupId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/wls-operator-exporter/pom.xml
+++ b/wls-operator-exporter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>wls-exporter-parent</artifactId>
         <groupId>com.oracle.wls.exporter</groupId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <artifactId>wls-operator-exporter</artifactId>


### PR DESCRIPTION
1. Address potential resource leak issue identified by Fortify
2. Update POMs for Oracle's open-source release criteria.