### PR TITLE
Include apache components in sidecar

### DIFF
--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/YamlDemo.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/YamlDemo.java
@@ -5,8 +5,6 @@ package com.oracle.wls.exporter;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import com.google.gson.JsonObject;
 import com.oracle.wls.exporter.domain.ExporterConfig;
@@ -14,6 +12,7 @@ import com.oracle.wls.exporter.domain.MBeanSelector;
 
 import static com.google.gson.JsonParser.parseString;
 import static com.oracle.wls.exporter.DemoInputs.RESPONSE;
+import static com.oracle.wls.exporter.DemoInputs.YAML_STRING3;
 import static com.oracle.wls.exporter.DemoInputs.compressedJsonForm;
 
 /**
@@ -22,8 +21,7 @@ import static com.oracle.wls.exporter.DemoInputs.compressedJsonForm;
 public class YamlDemo {
 
     public static void main(String... args) throws IOException {
-        String yamlString = String.join("\n", Files.readAllLines(Paths.get("/Users/rgold/Desktop/mohit.yml")));
-//        String yamlString = YAML_STRING3;
+        String yamlString = YAML_STRING3;
         System.out.println("The following configuration:\n" + yamlString);
         ExporterConfig exporterConfig = ExporterConfig.loadConfig(new ByteArrayInputStream(yamlString.getBytes()));
 

--- a/wls-exporter-sidecar/pom.xml
+++ b/wls-exporter-sidecar/pom.xml
@@ -47,6 +47,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
           <groupId>org.junit.jupiter</groupId>
           <artifactId>junit-jupiter</artifactId>
           <scope>test</scope>


### PR DESCRIPTION
Actually gets the https functionality to work in the sidecar. See https://build.weblogick8s.org:8443/job/weblogic-kubernetes-operator-kind-new/4259/

The problem was that I had built in a capability to fall back to a smaller http client based on JDK classes, if the apache classes weren't present - and they weren't, in the sidecar.

We actually don't need that capability any more, so I could pull it out, but this gets the sidecar working.

There are some other things that we might consider including in the 2.0 release, including:

1. selection of operator or WLS as a source for the domain name, if domain qualifier is enabled
2. some better diagnostics for some problems recently reported in the webapp version
3. a FAQ for those issues

And it is still possible that there is a problem when the admin port is enabled - I don't think we've tested that sufficiently for either the web app or sidecar case.