### PR TITLE
fix:  addressing indeterminate Map / JSON orderings in tests

### DIFF
--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/ExporterConfig.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/ExporterConfig.java
@@ -197,7 +197,7 @@ public class ExporterConfig {
 
         for (String key : first.getNestedSelectors().keySet())
             if (!first.getNestedSelectors().get(key).mayMergeWith(second.getNestedSelectors().get(key))) return false;
-        
+
         return true;
     }
 

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/ExporterConfig.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/ExporterConfig.java
@@ -197,7 +197,7 @@ public class ExporterConfig {
 
         for (String key : first.getNestedSelectors().keySet())
             if (!first.getNestedSelectors().get(key).mayMergeWith(second.getNestedSelectors().get(key))) return false;
-
+        
         return true;
     }
 

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MBeanSelector.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MBeanSelector.java
@@ -85,7 +85,7 @@ public class MBeanSelector {
 
     private void setValues(String[] values) {
         if (values.length == 0) throw new ConfigurationException("Values specified as empty array");
-
+        
         Set<String> uniqueValues = new HashSet<>(Arrays.asList(values));
         if (values.length != uniqueValues.size())
             reportDuplicateValues(values, uniqueValues);

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MBeanSelector.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MBeanSelector.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +38,7 @@ public class MBeanSelector {
     private String key;
     private String keyName;
     private String[] values = null;
-    private Map<String, MBeanSelector> nestedSelectors = new HashMap<>();
+    private Map<String, MBeanSelector> nestedSelectors = new LinkedHashMap<>();
     private QueryType queryType = QueryType.RUNTIME;
 
     private static MBeanSelector createDomainNameSelector() {
@@ -84,7 +85,7 @@ public class MBeanSelector {
 
     private void setValues(String[] values) {
         if (values.length == 0) throw new ConfigurationException("Values specified as empty array");
-        
+
         Set<String> uniqueValues = new HashSet<>(Arrays.asList(values));
         if (values.length != uniqueValues.size())
             reportDuplicateValues(values, uniqueValues);
@@ -257,7 +258,7 @@ public class MBeanSelector {
         mergedValues.addAll(second.getValuesAsList());
         values = mergedValues.toArray(new String[0]);
 
-        nestedSelectors = new HashMap<>();
+        nestedSelectors = new LinkedHashMap<>();
         nestedSelectors.putAll(first.nestedSelectors);
         for (String key : second.nestedSelectors.keySet()) {
             if (!nestedSelectors.containsKey(key))

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClientTestBase.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClientTestBase.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonParser;
 import com.meterware.pseudoserver.PseudoServer;
 import com.meterware.pseudoserver.PseudoServlet;
 import com.meterware.pseudoserver.WebResource;
@@ -138,7 +139,9 @@ abstract class WebClientTestBase {
 
         withWebClient("unprotected_put").doPutRequest(QUERY);
 
-        assertThat(sentInfo, equalTo(QUERY.getAsJson()));
+        JsonParser parser = new JsonParser();
+
+        assertThat(parser.parse(sentInfo), equalTo(parser.parse(QUERY.getAsJson())));
     }
 
     @SuppressWarnings({"FieldCanBeLocal", "unused"})

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MBeanSelectorTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MBeanSelectorTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
+import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Test;
 
 import static com.oracle.wls.exporter.domain.JsonPathMatcher.hasJsonPath;
@@ -311,8 +312,9 @@ public class MBeanSelectorTest {
     @Test
     public void generateJsonRequest() {
         MBeanSelector selector = MBeanSelector.create(ImmutableMap.of("applicationRuntimes", getApplicationMap()));
+        JsonParser parser = new JsonParser();
 
-        assertThat(selector.getRequest(), equalTo(compressedJsonForm(EXPECTED_JSON_REQUEST)));
+        assertThat(parser.parse(selector.getRequest()), equalTo(parser.parse(compressedJsonForm(EXPECTED_JSON_REQUEST))));
     }
 
     private Map<String, Object> getApplicationMap() {
@@ -374,8 +376,9 @@ public class MBeanSelectorTest {
     @Test
     public void whenNoValuesListedForSerlvets_generateJsonRequest() {
         MBeanSelector selector = MBeanSelector.create(ImmutableMap.of("applicationRuntimes", getNoServletValuesApplicationMap()));
+        JsonParser parser = new JsonParser();
 
-        assertThat(selector.getRequest(), equalTo(compressedJsonForm(EXPECTED_ALL_SERVLET_VALUES_JSON_REQUEST)));
+        assertThat(parser.parse(selector.getRequest()), equalTo(parser.parse(compressedJsonForm(EXPECTED_ALL_SERVLET_VALUES_JSON_REQUEST))));
     }
 
     private Map<String, Object> getNoServletValuesApplicationMap() {


### PR DESCRIPTION
**Description**
5 flaky tests are found using Nondex when running commands 
```mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex ``` under ```wls-exporter-core```
The reasons for test flakiness are that Java map API does not preserve the order of the key-value pairs, and that element orders in JSONObjects/JSONArrays are also not preserved. Comparing maps / JSON-likes by casting to string can fail when, for example, the Java version upgrades in the future, or when the code is run in different environment.

**Fixes**
- Using LinkedHashMap instead of HashMap to ensure deterministic order in maps.
- Using Gson's JsonParser routine to parse and compare JSON-formatted strings.