### PR TITLE
Add messages endpoint to sidecar

### DIFF
--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/AuthenticatedCall.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/AuthenticatedCall.java
@@ -24,7 +24,7 @@ public abstract class AuthenticatedCall {
     private final UrlBuilder urlBuilder;
 
 
-    public AuthenticatedCall(WebClientFactory webClientFactory, InvocationContext context) {
+    protected AuthenticatedCall(WebClientFactory webClientFactory, InvocationContext context) {
         this.webClientFactory = webClientFactory;
         this.context = context;
         this.urlBuilder = context.createUrlBuilder();

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/ConfigurationCall.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/ConfigurationCall.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
@@ -11,7 +11,7 @@ import com.oracle.wls.exporter.domain.ExporterConfig;
 
 public abstract class ConfigurationCall extends AuthenticatedCall {
 
-  public ConfigurationCall(WebClientFactory webClientFactory, InvocationContext context) {
+  protected ConfigurationCall(WebClientFactory webClientFactory, InvocationContext context) {
     super(webClientFactory, context);
   }
 
@@ -40,7 +40,7 @@ public abstract class ConfigurationCall extends AuthenticatedCall {
 
   abstract void reportUnableToUpdateConfiguration(InvocationContext context, ConfigurationException e) throws IOException;
 
-  static abstract class ConfigurationAction {
+  abstract static class ConfigurationAction {
 
     private ExporterConfig uploadedConfig;
 
@@ -49,8 +49,8 @@ public abstract class ConfigurationCall extends AuthenticatedCall {
         uploadedConfig = ExporterConfig.loadConfig(inputStream);
       } catch (ConfigurationException e) {
         throw e;
-      } catch (Throwable e) {
-        throw new RuntimeException("Unable to understand specified configuration");
+      } catch (Exception e) {
+        throw new ConfigurationException("Unable to understand specified configuration");
       }
     }
 
@@ -60,4 +60,6 @@ public abstract class ConfigurationCall extends AuthenticatedCall {
       return uploadedConfig;
     }
   }
+
+
 }

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/InvocationContext.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/InvocationContext.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
@@ -71,7 +71,7 @@ public interface InvocationContext {
   void setResponseHeader(String name, String value);
 
   /**
-   * Updates the response with a status but does not close he response stream.
+   * Updates the response with a status but does not close the response stream.
    * @param status an HTTP status code
    */
   void setStatus(int status);

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/MessagesCall.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/MessagesCall.java
@@ -1,0 +1,22 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.wls.exporter;
+
+import java.io.IOException;
+import java.io.PrintStream;
+
+public class MessagesCall extends AuthenticatedCall {
+
+  public MessagesCall(WebClientFactory webClientFactory, InvocationContext context) {
+    super(webClientFactory, context);
+  }
+
+  @Override
+  protected void invoke(WebClient webClient, InvocationContext context) throws IOException {
+    try (PrintStream out = context.getResponseStream()) {
+      for (String message : WlsRestExchanges.getExchanges())
+        out.println(message);
+    }
+  }
+}

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WlsRestExchanges.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WlsRestExchanges.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
@@ -16,7 +16,10 @@ public class WlsRestExchanges {
   public static final int MAX_EXCHANGES = 5;
   private static final String TEMPLATE = "REQUEST to %s:%n%s%nREPLY:%n%s%n";
 
-  public static final Queue<String> exchanges = new ConcurrentLinkedDeque<>();
+  private static final Queue<String> exchanges = new ConcurrentLinkedDeque<>();
+
+  private WlsRestExchanges() {
+  }
 
   /**
    * Returns a list of the most recent exchanges.

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/ConfigurationException.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/ConfigurationException.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2020, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter.domain;
@@ -17,7 +17,7 @@ public class ConfigurationException extends RuntimeException {
     static final String NO_QUERY_SYNC_URL = "query_sync defined without url";
     private final List<String> context = new ArrayList<>();
 
-    ConfigurationException(String description) {
+    public ConfigurationException(String description) {
         super(description);
     }
 

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/webapp/MessagesServlet.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/webapp/MessagesServlet.java
@@ -1,16 +1,18 @@
-// Copyright (c) 2019, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2019, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter.webapp;
 
 import java.io.IOException;
-import javax.servlet.ServletOutputStream;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.oracle.wls.exporter.WlsRestExchanges;
+import com.oracle.wls.exporter.MessagesCall;
+import com.oracle.wls.exporter.ServletInvocationContext;
+import com.oracle.wls.exporter.WebClientFactory;
+import com.oracle.wls.exporter.WebClientFactoryImpl;
 
 import static com.oracle.wls.exporter.WebAppConstants.MESSAGES_PAGE;
 
@@ -20,12 +22,21 @@ import static com.oracle.wls.exporter.WebAppConstants.MESSAGES_PAGE;
 @WebServlet("/" + MESSAGES_PAGE)
 public class MessagesServlet extends HttpServlet {
 
+    private final WebClientFactory webClientFactory;
+
+    public MessagesServlet() {
+        this(new WebClientFactoryImpl());
+    }
+
+    public MessagesServlet(WebClientFactory webClientFactory) {
+        this.webClientFactory = webClientFactory;
+    }
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        try(ServletOutputStream out = resp.getOutputStream()) {
-            for (String message : WlsRestExchanges.getExchanges())
-                out.println(message);
-        }
+        ServletUtils.setServer(req);
+        MessagesCall call = new MessagesCall(webClientFactory, new ServletInvocationContext(req, resp));
+        call.doWithAuthentication();
     }
 
 }

--- a/wls-exporter-sidecar/src/main/java/com/oracle/wls/exporter/sidecar/MetricsService.java
+++ b/wls-exporter-sidecar/src/main/java/com/oracle/wls/exporter/sidecar/MetricsService.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter.sidecar;
@@ -13,6 +13,7 @@ import com.oracle.wls.exporter.ConfigurationPutCall;
 import com.oracle.wls.exporter.ExporterCall;
 import com.oracle.wls.exporter.InvocationContext;
 import com.oracle.wls.exporter.LiveConfiguration;
+import com.oracle.wls.exporter.MessagesCall;
 import com.oracle.wls.exporter.WebClientFactory;
 import io.helidon.common.configurable.ThreadPoolSupplier;
 import io.helidon.webserver.Routing;
@@ -28,6 +29,7 @@ class MetricsService implements Service {
     private final AuthenticatedHandler metricsHandler = new AuthenticatedHandler(ExporterCall::new);
     private final AuthenticatedHandler configurationHandler = new AuthenticatedHandler(ConfigurationPutCall::new);
     private final MainHandler mainHandler = new MainHandler();
+    private final AuthenticatedHandler messagesHandler = new AuthenticatedHandler(MessagesCall::new);
     private final int listenPort;
 
     MetricsService(SidecarConfiguration configuration, WebClientFactory webClientFactory) {
@@ -48,6 +50,7 @@ class MetricsService implements Service {
         rules
               .get("/", mainHandler::dispatch)
               .get("/metrics", metricsHandler::dispatch)
+              .get("/messages", messagesHandler::dispatch)
               .put("/configuration", configurationHandler::dispatch);
     }
 
@@ -92,4 +95,5 @@ class MetricsService implements Service {
             context.close();
         }
     }
+
 }


### PR DESCRIPTION
Adds support for the `/messages` endpoint to the sidecar version of the exporter.

Some cleanup for problems flagged by Sonar