### PR TITLE
Display exporter version

### DIFF
--- a/build-helper-mojo/pom.xml
+++ b/build-helper-mojo/pom.xml
@@ -20,6 +20,12 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>2.2.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>3.8.6</version>
             <scope>provided</scope>
@@ -27,12 +33,6 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>3.8.6</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-artifact</artifactId>
             <version>3.8.6</version>
             <scope>provided</scope>
         </dependency>
@@ -62,10 +62,19 @@
             <artifactId>simplestub</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>

--- a/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/CopyExecutor.java
+++ b/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/CopyExecutor.java
@@ -4,13 +4,10 @@
 package com.oracle.wls.buildhelper;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 
 public interface CopyExecutor {
 
   Path toPath(File file);
-
-  void copyFile(Path sourcePath, Path targetPath) throws IOException;
 
 }

--- a/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/CopyExecutor.java
+++ b/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/CopyExecutor.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.buildhelper;

--- a/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/CopyExecutorImpl.java
+++ b/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/CopyExecutorImpl.java
@@ -4,11 +4,7 @@
 package com.oracle.wls.buildhelper;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 public class CopyExecutorImpl implements CopyExecutor {
 
@@ -17,9 +13,4 @@ public class CopyExecutorImpl implements CopyExecutor {
     return file.toPath();
   }
 
-  @Override
-  public void copyFile(Path sourcePath, Path targetPath) throws IOException {
-    Files.createDirectories(targetPath.getParent());
-    Files.copy(sourcePath, targetPath, REPLACE_EXISTING);
-  }
 }

--- a/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/FileCopyMojo.java
+++ b/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/FileCopyMojo.java
@@ -3,19 +3,22 @@
 
 package com.oracle.wls.buildhelper;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Optional;
-
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
 @Mojo(name = "copy", defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
-public class BuildHelperMojo extends AbstractMojo {
+public class FileCopyMojo extends AbstractMojo {
     @Parameter(required = true) private String sourceFile;
     @Parameter(required = true) private File targetFile;
     @Parameter private File userDir;
@@ -28,7 +31,8 @@ public class BuildHelperMojo extends AbstractMojo {
         Path target = toPath(targetFile);
         try {
             getLog().info("Copying " + source + " to " + target);
-            executor.copyFile(source, target);
+            Files.createDirectories(target.getParent());
+            Files.copy(source, target, REPLACE_EXISTING);
         } catch (IOException e) {
             throw new MojoExecutionException("Unable to copy " + source + " to " + target, e);
         }

--- a/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/FileCopyMojo.java
+++ b/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/FileCopyMojo.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022 Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.buildhelper;

--- a/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/GitTagExecutor.java
+++ b/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/GitTagExecutor.java
@@ -1,0 +1,24 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.wls.buildhelper;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * An interface for the system interaction functionality required to execute the GitTag mojo.
+ */
+interface GitTagExecutor {
+
+  /**
+   * Issues a command and returns the response.
+   * @param commandLine the command to execute
+   */
+  String runCommand(String... commandLine) throws IOException, MojoExecutionException;
+
+  Path toPath(File file);
+}

--- a/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/GitTagExecutorImpl.java
+++ b/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/GitTagExecutorImpl.java
@@ -1,0 +1,35 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.wls.buildhelper;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+
+public class GitTagExecutorImpl implements GitTagExecutor {
+  @Override
+  public String runCommand(String... commandLineStrings) throws IOException, MojoExecutionException {
+    try {
+      final Process vp = new ProcessBuilder(commandLineStrings).start();
+
+      vp.waitFor();
+
+      final BufferedReader br = new BufferedReader(new InputStreamReader(vp.getInputStream()));
+      return br.lines().collect(Collectors.joining("\n"));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new MojoExecutionException("Thread interrupted while running command " + String.join(" ", commandLineStrings));
+    }
+  }
+
+  @Override
+  public Path toPath(File file) {
+    return file.toPath();
+  }
+}

--- a/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/GitTagMojo.java
+++ b/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/GitTagMojo.java
@@ -1,0 +1,73 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.wls.buildhelper;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Mojo(name = "gitVersion", defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
+public class GitTagMojo extends AbstractMojo {
+
+  @Parameter(required = true, defaultValue = "${project.build.outputDirectory}/version.properties")
+  private File outputFile;
+  
+  private final GitTagExecutor executor;
+
+  GitTagMojo(GitTagExecutor executor) {
+    this.executor = executor;
+  }
+
+  @SuppressWarnings("unused")
+  public GitTagMojo() {
+    this(new GitTagExecutorImpl());
+  }
+
+  @Override
+  public void execute() throws MojoExecutionException {
+    try {
+      final String versionString = toVersionString(executor.runCommand("git", "describe", "--tag"));
+      final Path path = executor.toPath(outputFile);
+      Files.createDirectories(path.getParent());
+      Files.write(path, createProperties(versionString));
+    } catch (IOException e) {
+      throw new MojoExecutionException("Error writing " + outputFile + ": " + e );
+    }
+
+  }
+
+  private List<String> createProperties(String versionString) {
+    return Collections.singletonList("version=" + versionString);
+  }
+
+  // parses the result of 'git describe --tag' to describe the current code version/
+  private String toVersionString(String gitResponse) {
+    final String[] segments = gitResponse.split("-");
+    if (segments.length == 1 || segments.length == 2)
+      return gitResponse;
+    else
+      return formatVersionString(segments);
+  }
+
+  private String formatVersionString(String[] segments) {
+    final String commit = segments[segments.length - 1];
+    final String numCommits = segments[segments.length - 2];
+    final String versionParts = String.join("-", Arrays.copyOfRange(segments, 0, segments.length - 2));
+    return formatVersionString(commit, numCommits, versionParts);
+  }
+
+  private String formatVersionString(String commit, String numCommits, String versionParts) {
+    return commit + " (" + numCommits + " commits since " + versionParts + ")";
+  }
+}

--- a/build-helper-mojo/src/test/java/com/oracle/wls/buildhelper/GitTagMojoTest.java
+++ b/build-helper-mojo/src/test/java/com/oracle/wls/buildhelper/GitTagMojoTest.java
@@ -1,0 +1,149 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.wls.buildhelper;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GitTagMojoTest {
+  private final InMemoryFileSystem inMemoryFileSystem = InMemoryFileSystem.createInstance();
+  private final GitTagExecutorStub stub = new GitTagExecutorStub(inMemoryFileSystem);
+  private final GitTagMojo mojo = new GitTagMojo(stub);
+  private final File outputFile = new File("/a/b/v.properties");
+  private final Path outputPath = inMemoryFileSystem.getPath(outputFile.getAbsolutePath());
+
+  private MojoTestSupport mojoTestSupport;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    mojoTestSupport = new MojoTestSupport(GitTagMojo.class);
+    setMojoParameter("outputFile", outputFile);
+  }
+
+  @Test
+  void helperImplementsMojo() {
+    assertThat(mojo, instanceOf(AbstractMojo.class));
+  }
+
+  @Test
+  void mojoHasGoalAnnotation() {
+    assertThat(mojoTestSupport.getClassAnnotation(), notNullValue());
+  }
+
+  @Test
+  void mojoAnnotatedWithName() {
+    assertThat(mojoTestSupport.getClassAnnotation().get("name"), equalTo("gitVersion"));
+  }
+
+  @Test
+  void mojoAnnotatedWithDefaultPhase() {
+    assertThat(mojoTestSupport.getClassAnnotation().get("defaultPhase"), equalTo(LifecyclePhase.PREPARE_PACKAGE));
+  }
+
+  @Test
+  void hasRequiredOutputDirectoryParameter() throws NoSuchFieldException {
+    assertThat(mojoTestSupport.getParameterField("outputFile").getType(), equalTo(File.class));
+    assertThat(mojoTestSupport.getParameterAnnotation("outputFile").get("required"), is(true));
+    assertThat(mojoTestSupport.getParameterAnnotation("outputFile").get("defaultValue"), equalTo("${project.build.outputDirectory}/version.properties"));
+  }
+
+  @Test
+  void whenMojoExecuted_runCorrectGitCommand() throws Exception {
+    mojo.execute();
+
+    assertThat(stub.getExecutedCommand(), equalTo("git describe --tag"));
+  }
+
+  @Test
+  void whenMojoExecuted_generateOutputFile() throws Exception {
+    mojo.execute();
+
+    assertThat(Files.exists(outputPath), is(true));
+  }
+
+  @Test
+  void whenUnableToWriteFile_reportFailure() {
+    inMemoryFileSystem.throwExceptionOnAccess(outputFile.getAbsolutePath());
+
+    assertThrows(MojoExecutionException.class, mojo::execute);
+  }
+
+  @Test
+  void whenGitResponseIsVersionPlusHistory_createVersionProperty() throws Exception {
+    stub.setCommandResponse("v3.3.5-3-946-gcb4385f3aa");
+
+    mojo.execute();
+
+    assertThat(inMemoryFileSystem.getContents(outputFile.getAbsolutePath()),
+          containsString("version=gcb4385f3aa (946 commits since v3.3.5-3)"));
+  }
+
+  @Test
+  void whenGitResponseIsVersionOnly_createVersionProperty() throws Exception {
+    stub.setCommandResponse("v3.4-1");
+
+    mojo.execute();
+
+    assertThat(inMemoryFileSystem.getContents(outputFile.getAbsolutePath()), containsString("version=v3.4-1"));
+  }
+
+  @Test
+  void publicConstructorSuppliesLiveExecutor() throws NoSuchFieldException, IllegalAccessException {
+    GitTagMojo mojo = new GitTagMojo();
+
+    Field field = mojo.getClass().getDeclaredField("executor");
+    field.setAccessible(true);
+
+    assertThat(field.get(mojo), instanceOf(GitTagExecutor.class));
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private void setMojoParameter(String fieldName, Object value) throws Exception {
+    Field field = mojo.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(mojo, value);
+  }
+
+  static class GitTagExecutorStub implements GitTagExecutor {
+    private static final String DEFAULT_RESPONSE = "v3.3.5";
+    private final InMemoryFileSystem inMemoryFileSystem;
+    private String commandLine;
+    private String commandResponse = DEFAULT_RESPONSE;
+
+    GitTagExecutorStub(InMemoryFileSystem inMemoryFileSystem) {
+      this.inMemoryFileSystem = inMemoryFileSystem;
+    }
+
+    void setCommandResponse(String commandResponse) {
+      this.commandResponse = commandResponse;
+    }
+
+    String getExecutedCommand() {
+      return commandLine;
+    }
+
+    @Override
+    public String runCommand(String... commandLineStrings) {
+      this.commandLine = String.join(" ", commandLineStrings);
+      return commandResponse;
+    }
+
+    @Override
+    public Path toPath(File file) {
+      return inMemoryFileSystem.getPath(file.getAbsolutePath());
+    }
+  }
+}

--- a/build-helper-mojo/src/test/java/com/oracle/wls/buildhelper/InMemoryFileSystem.java
+++ b/build-helper-mojo/src/test/java/com/oracle/wls/buildhelper/InMemoryFileSystem.java
@@ -1,0 +1,314 @@
+// Copyright (c) 2018, 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.wls.buildhelper;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.*;
+
+import static com.meterware.simplestub.Stub.createStrictStub;
+
+public abstract class InMemoryFileSystem extends FileSystem {
+  private static InMemoryFileSystem instance;
+  private final FileSystemProviderStub provider = createStrictStub(FileSystemProviderStub.class);
+
+  public static InMemoryFileSystem createInstance() {
+    return instance = createStrictStub(InMemoryFileSystem.class);
+  }
+
+  public void defineFile(File file, String contents) {
+    instance.defineFileContents(file.getPath(), contents);
+  }
+
+  public void defineFile(String filePath, String contents) {
+    instance.defineFileContents(filePath, contents);
+  }
+
+  public String getContents(String filePath) {
+    return provider.fileContents.get(filePath);
+  }
+
+  public void throwExceptionOnAccess(String path) {
+    provider.throwExceptionOnAccess = path;
+  }
+
+  public Path getPath(@Nonnull String first, @Nonnull String... more) {
+    return PathStub.createPathStub(createPathString(first, more));
+  }
+
+  private void throwException(String pathString) {
+    throw new IllegalArgumentException(pathString);
+  }
+
+  private String createPathString(String first, String[] more) {
+    return more.length == 0 ? first : first + "/" + String.join("/", more);
+  }
+
+  @Override
+  public FileSystemProvider provider() {
+    return provider;
+  }
+
+  private void defineFileContents(String filePath, String contents) {
+    provider.fileContents.put(filePath, contents);
+  }
+
+  enum PathType {
+    DIRECTORY {
+      @Override
+      boolean isDirectory() {
+        return true;
+      }
+    },
+    FILE {
+      @Override
+      boolean isRegularFile() {
+        return true;
+      }
+    };
+
+    boolean isDirectory() {
+      return false;
+    }
+
+    boolean isRegularFile() {
+      return false;
+    }
+  }
+
+  abstract static class PathStub implements Path {
+    private final String filePath;
+
+    PathStub(String filePath) {
+      this.filePath = filePath;
+    }
+
+    static PathStub createPathStub(String pathString) {
+      return createStrictStub(PathStub.class, pathString);
+    }
+
+    @Override
+    public FileSystem getFileSystem() {
+      return instance;
+    }
+
+    @Override
+    public Path getFileName() {
+      return createPathStub(getLastElement());
+    }
+
+    protected String getLastElement() {
+      final int beginIndex = filePath.lastIndexOf(File.separatorChar);
+      return beginIndex < 0 ? filePath : filePath.substring(beginIndex + 1);
+    }
+
+    @Override
+    public Path getParent() {
+      final int beginIndex = filePath.lastIndexOf(File.separatorChar);
+      return beginIndex < 0 ? createPathStub("/") : createPathStub(filePath.substring(0, beginIndex));
+    }
+
+    @Override
+    public String toString() {
+      return filePath;
+    }
+  }
+
+  abstract static class FileSystemProviderStub extends FileSystemProvider {
+    private String throwExceptionOnAccess = null;
+
+    private final Map<String, String> fileContents = new HashMap<>();
+
+    static String getFilePath(Path path) {
+      if (!(path instanceof PathStub)) {
+        throw new IllegalArgumentException(path.getClass() + " not supported");
+      }
+
+      return ((PathStub) path).filePath;
+    }
+
+    @Override
+    public void checkAccess(Path path, AccessMode... modes) throws IOException {
+      if (null == getRawFileType(getFilePath(path))) {
+        throw new NoSuchFileException("File " + getFilePath(path) + " does not exist");
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <A extends BasicFileAttributes> A readAttributes(
+        Path path, Class<A> type, LinkOption... options) {
+      if (!type.equals(BasicFileAttributes.class)) {
+        throw new IllegalArgumentException("attributes type " + type + " not supported");
+      }
+      return (A) createAttributes(getFilePath(path));
+    }
+
+    @Override
+    public void createDirectory(Path dir, FileAttribute<?>... attrs) {
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public DirectoryStream<Path> newDirectoryStream(
+        Path dir, DirectoryStream.Filter<? super Path> filter) {
+      return createStrictStub(DirectoryStreamStub.class, this, getFilePath(dir));
+    }
+
+    @Override
+    public SeekableByteChannel newByteChannel(
+        Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) throws IOException {
+      if (path.toString().equals(throwExceptionOnAccess)) throw new IOException("for unit test");
+
+      if (!options.contains(StandardOpenOption.WRITE)) {
+        return Optional.ofNullable(fileContents.get(getFilePath(path)))
+              .map(s -> createStrictStub(ReadOnlyByteChannelStub.class, s))
+              .orElseThrow(() -> new FileNotFoundException(path.toString()));
+      } else {
+        return createStrictStub(WriteableByteChannelStub.class, getFilePath(path));
+      }
+    }
+
+    private BasicFileAttributes createAttributes(String filePath) {
+      return createStrictStub(BasicFileAttributesStub.class, getPathType(filePath));
+    }
+
+    private PathType getPathType(String filePath) {
+      return Optional.ofNullable(getRawFileType(filePath)).orElse(PathType.DIRECTORY);
+    }
+
+    @Nullable
+    private PathType getRawFileType(String filePath) {
+      for (String key : fileContents.keySet()) {
+        if (key.startsWith(filePath + '/')) {
+          return PathType.DIRECTORY;
+        }
+        if (key.equals(filePath)) {
+          return PathType.FILE;
+        }
+      }
+      return null;
+    }
+
+    @Override
+    public void copy(Path source, Path target, CopyOption... options) throws IOException {
+      if (source.toString().equals(throwExceptionOnAccess) || target.toString().equals(throwExceptionOnAccess))
+        throw new IOException("for unit test");
+
+      if (options.length != 1 && !StandardCopyOption.REPLACE_EXISTING.equals(options[0])) {
+        throw new IOException("Only REPLACE_EXISTING option is supported");
+      }
+
+      fileContents.put(getFilePath(target), fileContents.get(getFilePath(source)));
+    }
+  }
+
+  abstract static class BasicFileAttributesStub implements BasicFileAttributes {
+    private final PathType pathType;
+
+    BasicFileAttributesStub(PathType pathType) {
+      this.pathType = pathType;
+    }
+
+    @Override
+    public boolean isDirectory() {
+      return pathType.isDirectory();
+    }
+
+    @Override
+    public boolean isRegularFile() {
+      return pathType.isRegularFile();
+    }
+
+    @Override
+    public Object fileKey() {
+      return null;
+    }
+  }
+
+  abstract static class DirectoryStreamStub<T> implements DirectoryStream<T> {
+    final List<Path> paths = new ArrayList<>();
+
+    public DirectoryStreamStub(FileSystemProviderStub parent, String root) {
+      for (String key : parent.fileContents.keySet()) {
+        if (key.startsWith(root + "/")) {
+          paths.add(PathStub.createPathStub(key));
+        }
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    @Nonnull
+    public Iterator<T> iterator() {
+      return (Iterator<T>) paths.iterator();
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+
+  abstract static class ReadOnlyByteChannelStub implements SeekableByteChannel {
+    private final byte[] contents;
+    private int index = 0;
+
+    ReadOnlyByteChannelStub(String contents) {
+      this.contents = Optional.ofNullable(contents).map(String::getBytes).orElse(null);
+    }
+
+    @Override
+    public long size() {
+      return contents.length;
+    }
+
+    @Override
+    public int read(ByteBuffer dst) {
+      if (index >= contents.length) {
+        return -1;
+      }
+
+      dst.put(contents);
+      index = contents.length;
+      return contents.length;
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+
+  abstract static class WriteableByteChannelStub implements SeekableByteChannel {
+    private final String filePath;
+    private byte[] contents = new byte[0];
+
+    WriteableByteChannelStub(String filePath) {
+      this.filePath = filePath;
+    }
+
+    @Override
+    public int write(ByteBuffer src) {
+      byte[] newContents = new byte[contents.length + src.limit()];
+      System.arraycopy(contents, 0, newContents, 0, contents.length);
+      System.arraycopy(src.array(), src.position(), newContents, contents.length, src.limit() - src.position());
+      contents = newContents;
+      src.position(src.limit());
+      return contents.length;
+    }
+
+    @Override
+    public void close() {
+      instance.defineFileContents(filePath, new String(contents));
+    }
+  }
+}

--- a/wls-exporter-core/pom.xml
+++ b/wls-exporter-core/pom.xml
@@ -129,6 +129,21 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${maven-jar-plugin-version}</version>
             </plugin>
+            
+            <plugin>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>build-helper-mojo</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>get-version</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>gitVersion</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/LiveConfiguration.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/LiveConfiguration.java
@@ -3,19 +3,21 @@
 
 package com.oracle.wls.exporter;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.Map;
-import java.util.Optional;
-
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.oracle.wls.exporter.domain.ExporterConfig;
 import com.oracle.wls.exporter.domain.MBeanSelector;
 import com.oracle.wls.exporter.domain.QuerySyncConfiguration;
 import org.yaml.snakeyaml.Yaml;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
 
 /**
  * The repository for the current exporter configuration.
@@ -56,6 +58,16 @@ public class LiveConfiguration {
         return config;
     }
 
+    public static String getVersionString() {
+        try (InputStream in = LiveConfiguration.class.getClassLoader().getResourceAsStream("version.properties")) {
+            Properties properties = new Properties();
+            properties.load(in);
+            return properties.getProperty("version");
+
+        } catch (IOException e) {
+            return "** unknown version";
+        }
+    }
 
     public static void loadFromString(String yamlString) {
         Map<String, Object> yamlConfig = new Yaml().load(yamlString);

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/webapp/MainServlet.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/webapp/MainServlet.java
@@ -3,22 +3,19 @@
 
 package com.oracle.wls.exporter.webapp;
 
-import java.io.IOException;
+import com.oracle.wls.exporter.ConfigurationDisplay;
+import com.oracle.wls.exporter.LiveConfiguration;
+import com.oracle.wls.exporter.WebAppConstants;
+
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
-import com.oracle.wls.exporter.ConfigurationDisplay;
-import com.oracle.wls.exporter.LiveConfiguration;
-import com.oracle.wls.exporter.WebAppConstants;
-
-import static com.oracle.wls.exporter.WebAppConstants.APPEND_ACTION;
-import static com.oracle.wls.exporter.WebAppConstants.CONFIGURATION_PAGE;
-import static com.oracle.wls.exporter.WebAppConstants.EFFECT_OPTION;
-import static com.oracle.wls.exporter.WebAppConstants.REPLACE_ACTION;
+import static com.oracle.wls.exporter.WebAppConstants.*;
 
 /**
  * This servlet represents the 'landing page' for the exporter.
@@ -46,7 +43,7 @@ public class MainServlet extends HttpServlet {
     }
 
     private void displayMetricsLink(HttpServletRequest req, ServletOutputStream outputStream) throws IOException {
-        outputStream.println("<h2>This is the WebLogic Monitoring Exporter.</h2>");
+        outputStream.println("<h2>Oracle WebLogic Monitoring Exporter " + LiveConfiguration.getVersionString() + ".</h2>");
         outputStream.println("<p>The metrics are found at <a href=\"" + getMetricsLink(req) + "\">");
         outputStream.println(WebAppConstants.METRICS_PAGE + "</a> relative to this location.");
         outputStream.println("</p>");

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/webapp/MainServlet.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/webapp/MainServlet.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter.webapp;

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/InMemoryFileSystem.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/InMemoryFileSystem.java
@@ -1,21 +1,21 @@
-// Copyright (c) 2017, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
 
+import com.google.common.collect.ImmutableMap;
+import com.meterware.simplestub.Memento;
+import com.meterware.simplestub.StaticStubSupport;
+import com.oracle.wls.exporter.webapp.ServletUtils;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-
-import com.google.common.collect.ImmutableMap;
-import com.meterware.simplestub.Memento;
-import com.meterware.simplestub.StaticStubSupport;
-import com.oracle.wls.exporter.webapp.ServletUtils;
 
 import static com.meterware.simplestub.Stub.createStrictStub;
 


### PR DESCRIPTION
Read the version tag from Git and display it on the main page. 

If the built commit is not the one at which the tag was created, the actual commit ID will be displayed, along with the number of commits since the tag. 

For example, the current main page is titled:
```
Oracle WebLogic Monitoring Exporter a1d7c85 (22 commits since v2.0.7).
```