### PR TITLE
Add filtering by regular expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ queries:
       type: WebAppComponentRuntime
       prefix: webapp_config_
       key: name
+      includedKeyValues: "abc_.*"
+      excludedKeyValues: "abc_12.*"
       values: [deploymentState, contextRoot, sourceInfo, openSessionsHighCount]
       stringValues:
         status: [deployed, undeployed]
@@ -60,14 +62,16 @@ Note that if unable to contact the REST API using the inferred host and port, th
 The `query` field is more complex. Each query consists of a hierarchy of the [MBeans](https://docs.oracle.com/middleware/12213/wls/WLMBR/core/index.html), starting relative to `ServerRuntimes`.
 Within each section, there are a number of options:
 
-| Name           | Description                                                                                                                            |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| `key`          | The name of the attribute to use as a key for qualifiers in the output.                                                                |
-| `keyName`      | The name to use for the key in the qualifier; defaults to the name of the attribute.                                                   |
-| `prefix`       | A prefix to use for all the metrics gathered from the current level.                                                                   |
-| `values`       | The attributes for which metrics are to be output. If not specified and a prefix is defined, all values on the MBean will be selected. |
-| `type`         | A filter for subtypes. If specified, only those objects whose `type` attribute matches will be collected.                              |
-| `stringValues` | A map of string-valued metric names to a list of case-insensitive possible values. They will be converted to indexes of that list.     |
+| Name                | Description                                                                                                                            |
+|---------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `key`               | The name of the attribute to use as a key for qualifiers in the output.                                                                |
+| `includedKeyValues` | An optional filter. If specified, only entries whose key value matches the specified [regular expression](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html) will generate metrics.     |
+| `excludedKeyValues` | An optional filter. If specified, entries whose key value matches the specified regular expression will NOT generate metrics.          |
+| `keyName`           | The name to use for the key in the qualifier; defaults to the name of the attribute.                                                   |
+| `prefix`            | A prefix to use for all the metrics gathered from the current level.                                                                   |
+| `values`            | The attributes for which metrics are to be output. If not specified and a prefix is defined, all values on the MBean will be selected. |
+| `type`              | A filter for subtypes. If specified, only those objects whose `type` attribute matches will be collected.                              |
+| `stringValues`      | A map of string-valued metric names to a list of case-insensitive possible values. They will be converted to indexes of that list.     |
 
 Note that all fields other than the above, will be interpreted as collections of values.
 

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/ExporterCall.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/ExporterCall.java
@@ -1,15 +1,18 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.oracle.wls.exporter.domain.MBeanSelector;
+
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
-
-import com.oracle.wls.exporter.domain.MBeanSelector;
 
 import static com.oracle.wls.exporter.domain.MapUtils.isNullOrEmptyString;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
@@ -48,7 +51,7 @@ public class ExporterCall extends AuthenticatedCall {
   private void displayMetrics(WebClient webClient, MetricsStream metricsStream, MBeanSelector selector) throws IOException {
     try {
       Map<String, Object> metrics = getMetrics(webClient, selector);
-      if (metrics != null)
+      if (!metrics.isEmpty())
         sort(metrics).forEach(metricsStream::printMetric);
     } catch (RestQueryException e) {
       metricsStream.println(
@@ -56,7 +59,7 @@ public class ExporterCall extends AuthenticatedCall {
                   + selector.getPrintableRequest()));
     } catch (AuthenticationChallengeException e) {  // don't add a message for this case
       throw e;
-    } catch (IOException | RuntimeException | Error e) {
+    } catch (IOException | RuntimeException e) {
       WlsRestExchanges.addExchange(getQueryUrl(selector), selector.getRequest(), e.toString());
       throw e;
     }
@@ -71,16 +74,29 @@ public class ExporterCall extends AuthenticatedCall {
 
   private Map<String, Object> getMetrics(WebClient webClient, MBeanSelector selector) throws IOException {
     String jsonResponse = requestMetrics(webClient, selector);
-    if (isNullOrEmptyString(jsonResponse)) return null;
+    if (isNullOrEmptyString(jsonResponse)) return Collections.emptyMap();
 
     return LiveConfiguration.scrapeMetrics(selector, jsonResponse);
   }
 
   private String requestMetrics(WebClient webClient, MBeanSelector selector) throws IOException {
-    String url = getQueryUrl(selector);
-    String jsonResponse = webClient.withUrl(url).doPostRequest(selector.getRequest());
+    if (selector.needsNewKeys()) refreshKeys(webClient, selector);
+
+    final String url = getQueryUrl(selector);
+    final String jsonResponse = webClient.withUrl(url).doPostRequest(selector.getRequest());
     WlsRestExchanges.addExchange(url, selector.getRequest(), jsonResponse);
     return jsonResponse;
+  }
+
+  private void refreshKeys(WebClient webClient, MBeanSelector selector) throws IOException {
+    final String url = getQueryUrl(selector);
+    final String keyResponse = webClient.withUrl(url).doPostRequest(selector.getKeyRequest());
+    WlsRestExchanges.addExchange(url, selector.getKeyRequest(), keyResponse);
+    selector.offerKeys(toJsonObject(keyResponse));
+  }
+
+  private static JsonObject toJsonObject(String response) {
+      return JsonParser.parseString(response).getAsJsonObject();
   }
 
   private TreeMap<String, Object> sort(Map<String, Object> metrics) {

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/LiveConfiguration.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/LiveConfiguration.java
@@ -227,7 +227,9 @@ public class LiveConfiguration {
         }
 
         @Override
-        public void shareConfiguration(String configuration) {}
+        public void shareConfiguration(String configuration) {
+            // do nothing
+        }
 
         @Override
         public ConfigurationUpdate getUpdate() {

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientException.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientException.java
@@ -17,6 +17,10 @@ public class WebClientException extends RuntimeException {
         super(formatMessage(message, args), cause);
     }
 
+    WebClientException(String message, Object... args) {
+        super(formatMessage(message, args));
+    }
+
     private static String formatMessage(String message, Object... args) {
         return String.format(message, args);
     }

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MBeanSelector.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MBeanSelector.java
@@ -3,19 +3,13 @@
 
 package com.oracle.wls.exporter.domain;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Consumer;
+import com.google.gson.*;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import java.time.Clock;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * A description of an mbean to be selected by the generated JSON query and captured from the result.
@@ -23,24 +17,37 @@ import com.google.gson.GsonBuilder;
  * @author Russell Gold
  */
 public class MBeanSelector {
+    static final boolean USE_REGULAR_EXPRESSIONS = true;
+    @SuppressWarnings("FieldMayBeFinal") // allow unit tests to replace this.
+    private static Clock systemClock = Clock.systemUTC();
+
     static final String TYPE_KEY = "type";
     static final String PREFIX_KEY = "prefix";
     static final String QUERY_KEY = "key";
     static final String KEY_NAME = "keyName";
+    static final String INCLUDED_KEYS_KEY = "includedKeyValues";
+    static final String EXCLUDED_KEYS_KEY = "excludedKeyValues";
     static final String VALUES_KEY = "values";
     static final String STRING_VALUES_KEY = "stringValues";
     static final String TYPE_FIELD_NAME = "type";
     static final MBeanSelector DOMAIN_NAME_SELECTOR = createDomainNameSelector();
     static final String NESTING = "  ";
+    static final long KEY_UPDATE_INTERVAL_SECONDS = 60;
 
     private String type;
     private String prefix;
     private String key;
     private String keyName;
+    private String includedKeys;
+    private String excludedKeys;
+    private Pattern includedPattern;
+    private Pattern excludedPattern;
+    private final List<String> filter = new ArrayList<>();
     private List<String> values = new ArrayList<>();
     private Map<String, List<String>> stringValues;
     private Map<String, MBeanSelector> nestedSelectors = new LinkedHashMap<>();
     private QueryType queryType = QueryType.RUNTIME;
+    private long lastKeyTime = 0;
 
     private static MBeanSelector createDomainNameSelector() {
         Map<String,Object> yaml = new HashMap<>();
@@ -71,11 +78,18 @@ public class MBeanSelector {
                 case STRING_VALUES_KEY:
                     addStringValues(entry.getValue());
                     break;
+                case INCLUDED_KEYS_KEY:
+                    setIncludedKeys(entry.getValue().toString());
+                    break;
+                case EXCLUDED_KEYS_KEY:
+                    setExcludedKeys(entry.getValue().toString());
+                    break;
                 default:
                     addNestedSelector(entry.getKey(), entry.getValue());
                     break;
             }
         }
+        validate();
     }
 
     private void addNestedSelector(String key, Object selectorValue) {
@@ -87,14 +101,28 @@ public class MBeanSelector {
         }
     }
 
+    private void setIncludedKeys(String includedKeys) {
+        this.includedKeys = includedKeys;
+        includedPattern = Pattern.compile(this.includedKeys);
+    }
+
+    private void setExcludedKeys(String excludedKeys) {
+        this.excludedKeys = excludedKeys;
+        excludedPattern = Pattern.compile(this.excludedKeys);
+    }
+
     private void setValues(String[] values) {
         if (values.length == 0) throw new ConfigurationException("Values specified as empty array");
-        final List<String> valuesList = Arrays.asList(values);
-        final List<String> duplicates = getDuplicates(valuesList);
-        if (!duplicates.isEmpty())
-            throw new ConfigurationException("Duplicate values for " + duplicates);
+        final List<String> valuesList = getStringValues(values);
 
         this.values.addAll(valuesList);
+    }
+
+    private List<String> getStringValues(String[] values) {
+        final List<String> valuesList = Arrays.asList(values);
+        final List<String> duplicates = getDuplicates(valuesList);
+        if (!duplicates.isEmpty()) throw new ConfigurationException("Duplicate values for " + duplicates);
+        return valuesList;
     }
 
     private List<String> getDuplicates(List<String> values) {
@@ -116,17 +144,31 @@ public class MBeanSelector {
         }
     }
 
-    void appendNestedQuery(StringBuilder sb, String indent) {
+    private void validate() {
+        if (getKey() == null && includedKeys != null)
+            throw new ConfigurationException("Included key values specified without key field");
+        if (getKey() == null && excludedKeys != null)
+            throw new ConfigurationException("Excluded key values specified without key field");
+    }
+
+    /**
+     * Appends a readable form of this selector as a YAML query to the specified string builder.
+     * @param sb the string builder into which the selector should be added
+     * @param indent a string of spaces to indicate the current nesting
+     */
+    void appendAsNestedQuery(StringBuilder sb, String indent) {
         appendScalar(sb, indent, TYPE_KEY, type);
         appendScalar(sb, indent, PREFIX_KEY, prefix);
         appendScalar(sb, indent, QUERY_KEY, key);
+        appendScalar(sb, indent, INCLUDED_KEYS_KEY, includedKeys);
+        appendScalar(sb, indent, EXCLUDED_KEYS_KEY, excludedKeys);
         appendScalar(sb, indent, KEY_NAME, keyName);
-        appendValues(sb, indent, values);
+        appendStringList(sb, indent, VALUES_KEY, values);
         appendStringValues(sb, indent, stringValues);
 
         for (String qualifier : getNestedSelectors().keySet()) {
             sb.append(indent).append(qualifier).append(":\n");
-            getNestedSelectors().get(qualifier).appendNestedQuery(sb, indent + NESTING);
+            getNestedSelectors().get(qualifier).appendAsNestedQuery(sb, indent + NESTING);
         }
     }
 
@@ -135,12 +177,13 @@ public class MBeanSelector {
             sb.append(indent).append(name).append(": ").append(value).append('\n');
     }
 
-    private static void appendValues(StringBuilder sb, String indent, List<String> values) {
+    @SuppressWarnings("SameParameterValue")
+    private static void appendStringList(StringBuilder sb, String indent, String name, List<String> values) {
         if (values == null || values.isEmpty()) return;
         if (values.size() == 1)
-            appendScalar(sb, indent, VALUES_KEY, values.get(0));
+            appendScalar(sb, indent, name, values.get(0));
         else
-            appendArray(sb, indent, VALUES_KEY, values);
+            appendArray(sb, indent, name, values);
     }
 
     private static void appendArray(StringBuilder sb, String indent, String key, List<String> values) {
@@ -208,6 +251,20 @@ public class MBeanSelector {
     }
 
     /**
+     * Returns the regular expression that selects keys for which metrics are to be produced.
+     */
+    String getIncludedKeys() {
+        return includedKeys;
+    }
+
+    /**
+     * Returns the regular expression that selects keys for which metrics are not to be produced.
+     */
+    String getExcludedKeys() {
+        return excludedKeys;
+    }
+
+    /**
      * Returns the names of fields in the underlying mbeans which should be exported.
      * @return an array of field names.
      */
@@ -235,7 +292,7 @@ public class MBeanSelector {
      * @return a JSON string
      */
     public String getPrintableRequest() {
-        return new GsonBuilder().setPrettyPrinting().create().toJson(createQuerySpec());
+        return toQuerySpec().toJson(new GsonBuilder().setPrettyPrinting().create());
     }
 
     /**
@@ -243,17 +300,15 @@ public class MBeanSelector {
      * @return a JSON string
      */
     public String getRequest() {
-        return new Gson().toJson(createQuerySpec());
-    }
-
-    private JsonQuerySpec createQuerySpec() {
-        return toQuerySpec();
+        return toQuerySpec().toJson(new Gson());
     }
 
     JsonQuerySpec toQuerySpec() {
         JsonQuerySpec spec = new JsonQuerySpec();
         if (!useAllValues())
             selectQueryFields(spec, getQueryValues());
+        if (!filter.isEmpty())
+            spec.setFilter(key, filter);
 
         for (Map.Entry<String, MBeanSelector> selector : nestedSelectors.entrySet())
             spec.addChild(selector.getKey(), selector.getValue().toQuerySpec());
@@ -272,6 +327,102 @@ public class MBeanSelector {
     }
 
     /**
+     * Returns a JSON string query to be sent to the REST service.
+     * @return a JSON string
+     */
+    public String getKeyRequest() {
+        return toKeyQuerySpec().toJson(new Gson());
+    }
+
+    JsonQuerySpec toKeyQuerySpec() {
+        JsonQuerySpec spec = new JsonQuerySpec();
+        if (currentSelectorHasFilter()) spec.addFields(key);
+
+        for (Map.Entry<String, MBeanSelector> selector : nestedSelectors.entrySet())
+            spec.addChild(selector.getKey(), selector.getValue().toKeyQuerySpec());
+
+        return spec;
+    }
+
+    /**
+     * Returns true if this selector or one of its children needs an updated set of keys.
+     */
+    public boolean needsNewKeys() {
+        return hasFilter() && (hasNoKeys() || keysAreObsolete());
+    }
+
+    private boolean hasNoKeys() {
+        return lastKeyTime == 0;
+    }
+
+    private boolean keysAreObsolete() {
+        return secondsSinceKeyUpdate() >= KEY_UPDATE_INTERVAL_SECONDS;
+    }
+
+    private long secondsSinceKeyUpdate() {
+        return (systemClock.millis() - lastKeyTime) / 1000;
+    }
+
+    private boolean hasFilter() {
+        return currentSelectorHasFilter() || nestedSelectorHasFilter();
+    }
+
+    private boolean currentSelectorHasFilter() {
+        return includedKeys != null || excludedKeys != null;
+    }
+
+    private boolean nestedSelectorHasFilter() {
+        return nestedSelectors.values().stream().anyMatch(MBeanSelector::hasFilter);
+    }
+
+    public void offerKeys(JsonObject keyResponse) {
+        this.lastKeyTime = systemClock.millis();
+
+        for (String subElementKey : keyResponse.keySet()) {
+            final MBeanSelector mBeanSelector = getSelector(subElementKey);
+            if (mBeanSelector != null) {
+                mBeanSelector.offerKeys(keyResponse.get(subElementKey).getAsJsonObject());
+            }
+        }
+
+        asStream(keyResponse.get("items")).map(this::getKeyValue).filter(this::isSelectedKey).forEach(filter::add);
+    }
+
+    private MBeanSelector getSelector(String subElementKey) {
+        return getNestedSelectors().get(subElementKey);
+    }
+
+    private Stream<JsonElement> asStream(JsonElement element) {
+        final JsonArray ja = Optional.ofNullable(element)
+              .filter(JsonElement::isJsonArray)
+              .map(JsonElement::getAsJsonArray)
+              .orElse(new JsonArray());
+
+        return StreamSupport.stream(ja.spliterator(), false);
+    }
+
+    private String getKeyValue(JsonElement item) {
+        final JsonElement jsonElement = item.getAsJsonObject().get(key);
+        if (jsonElement.isJsonPrimitive() && jsonElement.getAsJsonPrimitive().isString()) {
+            return jsonElement.getAsJsonPrimitive().getAsString();
+        } else {
+            return null;
+        }
+    }
+
+    private boolean isSelectedKey(String foundKey) {
+        return foundKey != null && isIncluded(foundKey) && !isExcluded(foundKey);
+    }
+
+    private boolean isIncluded(String foundKey) {
+        return includedPattern == null || includedPattern.matcher(foundKey).matches();
+    }
+
+    private boolean isExcluded(String foundKey) {
+        return excludedPattern != null && excludedPattern.matcher(foundKey).matches();
+    }
+
+    /**
      * Merges this selector with the specified one. Returns the result of the merge.
      * @param selector a new selector whose attributes are to be combined with this one
      * @return the combined selector
@@ -281,15 +432,35 @@ public class MBeanSelector {
     }
 
     private MBeanSelector(MBeanSelector first, MBeanSelector second) {
+        copyScalars(first);
+        combineValues(first, second);
+        combineStringValues(first, second);
+        combineNestedSelectors(first, second);
+    }
+
+    private void copyScalars(MBeanSelector first) {
         this.type = first.type;
         this.prefix = first.prefix;
         this.key = first.key;
         this.keyName = first.keyName;
+        Optional.ofNullable(first.includedKeys).ifPresent(this::setIncludedKeys);
+        Optional.ofNullable(first.excludedKeys).ifPresent(this::setExcludedKeys);
+    }
 
+    private void combineValues(MBeanSelector first, MBeanSelector second) {
         final Set<String> mergedValues = new HashSet<>(first.getValuesAsList());
         mergedValues.addAll(second.getValuesAsList());
         values = new ArrayList<>(mergedValues);
+    }
 
+    private void combineStringValues(MBeanSelector first, MBeanSelector second) {
+        final Map<String, List<String>> mergedStringValues = new HashMap<>();
+        if (first.stringValues != null) mergedStringValues.putAll(first.stringValues);
+        if (second.stringValues != null) mergedStringValues.putAll(second.stringValues);
+        if (!mergedStringValues.isEmpty()) stringValues = mergedStringValues;
+    }
+
+    private void combineNestedSelectors(MBeanSelector first, MBeanSelector second) {
         nestedSelectors = new LinkedHashMap<>();
         nestedSelectors.putAll(first.nestedSelectors);
         for (String k : second.nestedSelectors.keySet()) {
@@ -353,7 +524,7 @@ public class MBeanSelector {
         return -1;
     }
 
-    void processMetrics(Map<String, Object> metrics, Consumer<Map<String, String>> processMetrics) {
-        queryType.processMetrics(metrics, processMetrics);
+    void postProcessMetrics(Map<String, Object> metrics, MetricsProcessor processor) {
+        queryType.postProcessMetrics(metrics, processor);
     }
 }

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MapUtils.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MapUtils.java
@@ -97,6 +97,8 @@ public class MapUtils {
         Object value = map.get(key);
         if (value instanceof List)
             return toStringArray((List<Object>) value);
+        else if (value == null)
+            throw createBadTypeException(key, value, "an array of strings");
         else if (!value.getClass().isArray())
             return new String[]{value.toString()};
         else if (value.getClass().getComponentType() == String.class)

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MetricsProcessor.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MetricsProcessor.java
@@ -1,0 +1,15 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.wls.exporter.domain;
+
+import java.util.Map;
+
+interface MetricsProcessor {
+
+  /**
+   * Uses the specified metrics to update configuration information.
+   * @param metrics a set of data scraped from a WebLogic Server response
+   */
+  void updateConfiguration(Map<String, Object> metrics);
+}

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ClockStub.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ClockStub.java
@@ -1,0 +1,27 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.wls.exporter;
+
+import java.time.Clock;
+import java.time.Instant;
+
+/**
+ * A unit-test implementation of the Clock interface.
+ */
+abstract public class ClockStub extends Clock {
+  private long currentMsec = 1000L;
+
+  public void setCurrentMsec(long currentMsec) {
+    this.currentMsec = currentMsec;
+  }
+
+  public void incrementSeconds(long seconds) {
+    this.currentMsec += 1000 * seconds;
+  }
+
+  @Override
+  public Instant instant() {
+    return Instant.ofEpochMilli(currentMsec);
+  }
+}

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ConfigurationUpdaterImplTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ConfigurationUpdaterImplTest.java
@@ -3,9 +3,6 @@
 
 package com.oracle.wls.exporter;
 
-import java.time.Clock;
-import java.time.Instant;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -147,20 +144,4 @@ class ConfigurationUpdaterImplTest {
         assertThat(errorLog.getErrors(), containsString("Unable to reach server"));
     }
 
-    static abstract class ClockStub extends Clock {
-        private long currentMsec;
-
-        void setCurrentMsec(long currentMsec) {
-            this.currentMsec = currentMsec;
-        }
-
-        void incrementSeconds(long seconds) {
-            this.currentMsec += 1000 * seconds;
-        }
-
-        @Override
-        public Instant instant() {
-            return Instant.ofEpochMilli(currentMsec);
-        }
-    }
 }

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClientFactoryStub.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClientFactoryStub.java
@@ -3,20 +3,16 @@
 
 package com.oracle.wls.exporter;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
 import com.google.gson.Gson;
+
+import java.io.IOException;
+import java.util.*;
 
 import static com.meterware.simplestub.Stub.createStrictStub;
 
 public class WebClientFactoryStub implements WebClientFactory {
     private final WebClientStub webClient = createStrictStub(WebClientStub.class);
+    private int queryIndex = 0;
 
     @Override
     public WebClient createClient() {
@@ -32,9 +28,16 @@ public class WebClientFactoryStub implements WebClientFactory {
         webClient.addJsonResponse(json);
     }
 
+    int getNumQueriesSent() {
+        return webClient.jsonQueries.size();
+    }
 
     String getSentQuery() {
-        return webClient.jsonQuery;
+        if (webClient.jsonQueries.size() <= queryIndex)
+            throw new WebClientException(
+                  "Attempted to read query %n but only %n were sent", queryIndex+1, getNumQueriesSent());
+
+        return webClient.jsonQueries.get(queryIndex++);
     }
 
     String getPostedString() {
@@ -79,7 +82,7 @@ public class WebClientFactoryStub implements WebClientFactory {
         private final static String WLS_SEARCH_PATH = "/management/weblogic/latest/serverRuntime/search";
 
         private String url;
-        private String jsonQuery;
+        private final List<String> jsonQueries = new ArrayList<>();
         private final List<TestResponse> testResponses = new ArrayList<>();
         private Iterator<TestResponse> responses;
         private final Map<String, String> addedHeaders = new HashMap<>();
@@ -140,7 +143,7 @@ public class WebClientFactoryStub implements WebClientFactory {
         public String doPostRequest(String postBody) {
             if (url == null) throw new NullPointerException("No URL specified");
             sentHeaders = Collections.unmodifiableMap(addedHeaders);
-            this.jsonQuery = postBody;
+            this.jsonQueries.add(postBody);
 
             return getResult(getNextResponse());
         }
@@ -211,6 +214,12 @@ public class WebClientFactoryStub implements WebClientFactory {
         @Override
         public String getJsonResponse() {
             return jsonResponse;
+        }
+    }
+
+    static class QueryTestException extends WebClientException {
+        public QueryTestException(String message) {
+            super(message);
         }
     }
 }

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MetricsScraperTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MetricsScraperTest.java
@@ -3,20 +3,18 @@
 
 package com.oracle.wls.exporter.domain;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonObject;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static com.google.gson.JsonParser.parseString;
 import static com.oracle.wls.exporter.domain.MetricMatcher.hasMetric;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.anEmptyMap;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 
 /**
  * @author Russell Gold
@@ -177,7 +175,9 @@ class MetricsScraperTest {
     }
 
     private void generateNestedMetrics(Map<String,Object> map, String jsonString, String parentQualifiers) {
-        scraper.scrapeSubObject(getJsonResponse(jsonString), MBeanSelector.create(map), parentQualifiers);
+        final JsonObject subObject = getJsonResponse(jsonString);
+        final MBeanSelector selector = MBeanSelector.create(map);
+        scraper.createDelegate(selector, subObject).scrapeSubObjects(parentQualifiers);
     }
 
     private JsonObject getJsonResponse(String jsonString) {


### PR DESCRIPTION
Adds filtering with regular expressions. For example:

```
    componentRuntimes:
      type: WebAppComponentRuntime
      prefix: webapp_config_
      key: name
      includedKeyValues: "abc_.*"
      excludedKeyValues: "abc_12.*"
      values: [deploymentState, contextRoot, sourceInfo, openSessionsHighCount]
```

will include all apps whose names begin with `abc_` as long as they don't begin with `abc_12`.

