### PR TITLE
Don't change default locale; add version metric

### DIFF
--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/ExporterCall.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/ExporterCall.java
@@ -3,16 +3,15 @@
 
 package com.oracle.wls.exporter;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.oracle.wls.exporter.domain.MBeanSelector;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collections;
-import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.oracle.wls.exporter.domain.MBeanSelector;
 
 import static com.oracle.wls.exporter.domain.MapUtils.isNullOrEmptyString;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
@@ -21,7 +20,6 @@ public class ExporterCall extends AuthenticatedCall {
 
   public ExporterCall(WebClientFactory webClientFactory, InvocationContext context) {
     super(webClientFactory, context);
-    Locale.setDefault(Locale.US);
   }
 
   @Override
@@ -41,7 +39,7 @@ public class ExporterCall extends AuthenticatedCall {
     try {
       for (MBeanSelector selector : LiveConfiguration.getQueries())
         displayMetrics(webClient, metricsStream, selector);
-      metricsStream.printPerformanceMetrics();
+      metricsStream.printPlatformMetrics();
     } catch (RestPortConnectionException e) {
       reportFailure(e);
       webClient.setRetryNeeded();

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ExporterServletTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ExporterServletTest.java
@@ -3,14 +3,12 @@
 
 package com.oracle.wls.exporter;
 
-import java.io.BufferedReader;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
 import java.io.IOException;
-import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
 
 import com.google.common.collect.ImmutableMap;
 import com.oracle.wls.exporter.webapp.ExporterServlet;
@@ -324,29 +322,7 @@ class ExporterServletTest {
 
         servlet.doGet(request, response);
 
-        assertThat(toHtml(response), containsString("wls_scrape_mbeans_count_total{instance=\"myhost:7654\"} 6"));
-    }
-
-    @Test
-    void onGetInForeignLocale_performanceMetricsUsePeriodForFloatingPoint() throws Exception {
-        factory.addJsonResponse(getGroupResponseMap());
-        initServlet(CONFIG_WITH_CATEGORY_VALUE);
-
-        Locale.setDefault(Locale.FRANCE);
-        servlet.doGet(request, response);
-
-        assertThat(getMetricValue("wls_scrape_duration_seconds"), containsString("."));
-    }
-
-    @SuppressWarnings("SameParameterValue")
-    private String getMetricValue(String metricsName) throws IOException {
-        String line;
-        BufferedReader reader = new BufferedReader(new StringReader(toHtml(response)));
-        do {
-            line = reader.readLine();
-        } while (line != null && !line.contains(metricsName));
-
-        return (line == null) ? "" : line.split(" ")[1];
+        assertThat(toHtml(response), containsString("wls_scrape_mbeans_count_total"));
     }
 
     @Test

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MetricsScraperTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MetricsScraperTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.gson.JsonParser.parseString;
 import static com.oracle.wls.exporter.domain.MetricMatcher.hasMetric;
+import static com.oracle.wls.exporter.domain.MetricMatcher.hasNoSuchMetric;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
@@ -301,8 +302,8 @@ class MetricsScraperTest {
     void whenGenerateHierarchicalMetrics_ignoresNonNumericValues() {
         generateNestedMetrics(twoLevelMap, TWO_LEVEL_RESPONSE);
 
-        assertThat(scraper.getMetrics(), not(hasMetric("component_sourceInfo{component=\"ejb30_weblogic\"}", "weblogic.war")));
-        assertThat(scraper.getMetrics(), not(hasMetric("component_internal{component=\"ejb30_weblogic\"}", "true")));
+        assertThat(scraper.getMetrics(), hasNoSuchMetric("component_sourceInfo{component=\"ejb30_weblogic\"}"));
+        assertThat(scraper.getMetrics(), hasNoSuchMetric("component_internal{component=\"ejb30_weblogic\"}"));
     }
 
     @Test

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/matchers/PrometheusMetricsMatcher.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/matchers/PrometheusMetricsMatcher.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2020, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter.matchers;
@@ -18,6 +18,14 @@ public class PrometheusMetricsMatcher extends org.hamcrest.TypeSafeDiagnosingMat
 
     public static PrometheusMetricsMatcher followsPrometheusRules() {
         return new PrometheusMetricsMatcher();
+    }
+
+    /**
+     * Given a line with a described metric, returns the actual metric string.
+     * @param metric a line containing a qualified name and a Prometheus metric
+     */
+    public static String getMetricValue(String metric) {
+        return metric.substring(metric.lastIndexOf(' ')).trim();
     }
 
     @Override
@@ -51,7 +59,7 @@ public class PrometheusMetricsMatcher extends org.hamcrest.TypeSafeDiagnosingMat
         if (Strings.isNullOrEmpty(metric) || metric.trim().startsWith("#")) return false;
         if (!metric.contains(" ")) return false;
 
-        String metricValue = metric.split(" ")[1];
+        String metricValue = getMetricValue(metric);
 
         try {
             Double.parseDouble(metricValue.trim());


### PR DESCRIPTION
This change addresses two issues:

- issue #165 adds a new metric, 'exporter_version` which reports the actual version of the current exporter, and
- issue #213 removes the setting of the default locale and tests that the metrics are still displayed in US format