### PR TITLE
Reimplement platform-independent metrics printing

### DIFF
--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/MetricsStreamTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/MetricsStreamTest.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableMap;
 import com.meterware.simplestub.Memento;
 import com.meterware.simplestub.StaticStubSupport;
 import com.meterware.simplestub.SystemPropertySupport;
-import com.oracle.wls.exporter.matchers.PrometheusMetricsMatcher;
 import com.oracle.wls.exporter.webapp.HttpServletRequestStub;
 import com.oracle.wls.exporter.webapp.ServletUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -35,6 +34,7 @@ import static org.hamcrest.Matchers.hasItems;
  * @author Russell Gold
  */
 class MetricsStreamTest {
+    private static final String Linux_LINE_SEPARATOR = "\n";
     private static final long NANOSEC_PER_SECONDS = 1000000000;
     private static final String LINE_SEPARATOR = "line.separator";
     private static final String WINDOWS_LINE_SEPARATOR = "\r\n";
@@ -79,7 +79,7 @@ class MetricsStreamTest {
     }
 
     @Test
-    void whenMetricsPrinted_eachHasItsOwnLineSeparatedByCarriageReturns() {
+    void whenMetricsPrinted_eachHasItsOwnLineSeparatedByLinuxLineSeparators() {
         metrics.printMetric("a", 12);
         metrics.printMetric("b", 120);
         metrics.printMetric("c", 0);
@@ -88,7 +88,7 @@ class MetricsStreamTest {
     }
 
     @Test
-    void whenMetricsPrintedOnWindows_eachHasItsOwnLineSeparatedByCarriageReturns() throws NoSuchFieldException {
+    void whenMetricsPrintedOnWindows_eachHasItsOwnLineSeparatedByLinuxLineSeparators() throws NoSuchFieldException {
         simulateWindows();
 
         metrics.printMetric("a", 12);
@@ -106,9 +106,13 @@ class MetricsStreamTest {
 
     private List<String> getPrintedMetricValues() {
         return Arrays.stream(getPrintedMetrics()
-              .split(System.lineSeparator()))
-              .map(PrometheusMetricsMatcher::getMetricValue)
+              .split(Linux_LINE_SEPARATOR))
+              .map(this::getMetricValue)
               .collect(Collectors.toList());
+    }
+
+    private String getMetricValue(String metricLine) {
+        return metricLine.substring(metricLine.lastIndexOf(' ') + 1);
     }
 
     @Test

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/matchers/PrometheusMetricsMatcher.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/matchers/PrometheusMetricsMatcher.java
@@ -20,14 +20,6 @@ public class PrometheusMetricsMatcher extends org.hamcrest.TypeSafeDiagnosingMat
         return new PrometheusMetricsMatcher();
     }
 
-    /**
-     * Given a line with a described metric, returns the actual metric string.
-     * @param metric a line containing a qualified name and a Prometheus metric
-     */
-    public static String getMetricValue(String metric) {
-        return metric.substring(metric.lastIndexOf(' ')).trim();
-    }
-
     @Override
     protected boolean matchesSafely(String metricsList, Description description) {
         String[] metrics = Arrays.stream(metricsList.split("\n"))
@@ -67,6 +59,10 @@ public class PrometheusMetricsMatcher extends org.hamcrest.TypeSafeDiagnosingMat
         } catch (NumberFormatException e) {
             return true;
         }
+    }
+
+    private static String getMetricValue(String metric) {
+        return metric.substring(metric.lastIndexOf(' ')).trim();
     }
 
     private boolean metricsInOrder(Description description, String[] metrics) {


### PR DESCRIPTION
My changes for issue #214 broke my previous fix for issue #16 - and the unit tests didn't catch the revert. I have re-implemented this by explicitly creating a line-ending constant to clarify the code and separating the numeric formatting from the metrics printing.

The filer has confirmed that this fixes the issue.