### PR TITLE
Manage wls-management-services sessions in exporter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019, 2022, Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023, Oracle and/or its affiliates.
     Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -109,14 +109,26 @@
                 <plugin>
                     <artifactId>maven-war-plugin</artifactId>
                     <version>${maven-war-plugin-version}</version>
+                    <executions>
+                        <execution>
+                            <id>notices</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>war</goal>
+                            </goals>
+                            <configuration>
+                                <failOnMissingWebXml>false</failOnMissingWebXml>
+                                <warSourceDirectory>${configuration.directory}</warSourceDirectory>
+                                <webResources>
+                                    <resource>
+                                        <directory>${project.basedir}/../src/main/notices</directory>
+                                    </resource>
+                                </webResources>
+                            </configuration>
+                        </execution>
+                    </executions>
                     <configuration>
                         <failOnMissingWebXml>false</failOnMissingWebXml>
-                        <warSourceDirectory>${configuration.directory}</warSourceDirectory>
-                        <webResources>
-                            <resource>
-                                <directory>${project.basedir}/../src/main/notices</directory>
-                            </resource>
-                        </webResources>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/AuthenticatedCall.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/AuthenticatedCall.java
@@ -1,15 +1,24 @@
-// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.oracle.wls.exporter.domain.MBeanSelector;
 import com.oracle.wls.exporter.domain.QueryType;
 
+import static com.oracle.wls.exporter.WebAppConstants.AUTHENTICATION_CHALLENGE_HEADER;
+import static com.oracle.wls.exporter.WebAppConstants.COOKIE_HEADER;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
@@ -19,10 +28,26 @@ import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
  * and the WLS RESTful Management services, thus using that service's security.
  */
 public abstract class AuthenticatedCall {
+
+    /**
+     * The length of time in seconds after which a cookie is deemed to have expired.
+     */
+    static final long COOKIE_LIFETIME_SECONDS = 1000L;
+
+    /**
+     * A map of authentication credentials to lists of cookies. The cookies will be sent on any request with
+     * the specified credentials.
+     */
+    private static final Map<String,List<Cookie>> COOKIES = new HashMap<>();
+
     private final WebClientFactory webClientFactory;
     private final InvocationContext context;
     private final UrlBuilder urlBuilder;
 
+    // For unit testing only
+    static void clearCookies() {
+        COOKIES.clear();
+    }
 
     protected AuthenticatedCall(WebClientFactory webClientFactory, InvocationContext context) {
         this.webClientFactory = webClientFactory;
@@ -46,13 +71,57 @@ public abstract class AuthenticatedCall {
         final WebClient webClient = webClientFactory.createClient();
         webClient.addHeader("X-Requested-By", "rest-exporter");
 
-        setAuthentication(webClient);
+        webClient.setAuthentication(context.getAuthenticationHeader());
+        getCookies(context.getAuthenticationHeader()).forEach(c -> webClient.addHeader(COOKIE_HEADER, c));
+        webClient.onSetCookieReceivedDo(this::handleNewCookie);
+        webClient.onSetCookieReceivedDo(c -> webClient.addHeader(COOKIE_HEADER, c));
         return webClient;
     }
 
-    protected void setAuthentication(WebClient webClient) {
-        webClient.setAuthentication(context.getAuthenticationHeader());
-     }
+    public List<String> getCookies(String credentials) {
+        final OffsetDateTime now = SystemClock.now();
+        final List<Cookie> cookieList = getCookieList(credentials);
+        cookieList.removeIf(c -> c.isExpiredAt(now));
+        
+        return cookieList.stream().map(Cookie::getValue).collect(Collectors.toList());
+    }
+
+    private List<Cookie> getCookieList(String credentials) {
+        return Optional.ofNullable(COOKIES.get(credentials)).orElse(Collections.emptyList());
+    }
+
+    void handleNewCookie(String cookieHeader) {
+        if (context.getAuthenticationHeader() == null) return;
+
+        final Cookie cookie = new Cookie(cookieHeader);
+        COOKIES
+              .computeIfAbsent(context.getAuthenticationHeader(), h -> new ArrayList<>())
+              .add(cookie);
+    }
+
+    private static class Cookie {
+        private final String value;
+        private final OffsetDateTime expirationTime = SystemClock.now().plusSeconds(COOKIE_LIFETIME_SECONDS);
+
+        Cookie(String cookieHeader) {
+            this.value = trimParameters(cookieHeader);
+        }
+
+        String getValue() {
+            return value;
+        }
+
+        boolean isExpiredAt(OffsetDateTime now) {
+            return now.isAfter(expirationTime);
+        }
+
+        private String trimParameters(String cookieHeader) {
+          if (!cookieHeader.contains(";"))
+            return cookieHeader;
+          else
+            return cookieHeader.substring(0, cookieHeader.indexOf(';'));
+        }
+    }
 
     /**
      * Performs a servlet action, wrapping it with authentication handling.
@@ -71,7 +140,7 @@ public abstract class AuthenticatedCall {
         } catch (ForbiddenException e) {
             context.sendError(HTTP_FORBIDDEN, "Not authorized");
         } catch (AuthenticationChallengeException e) {
-            context.setResponseHeader("WWW-Authenticate", e.getChallenge());
+            context.setResponseHeader(AUTHENTICATION_CHALLENGE_HEADER, e.getChallenge());
             context.sendError(HTTP_UNAUTHORIZED, "Authentication required");
         } catch (ServerErrorException e) {
             final int status = e.getStatus();

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/AuthenticatedCall.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/AuthenticatedCall.java
@@ -72,10 +72,16 @@ public abstract class AuthenticatedCall {
         webClient.addHeader("X-Requested-By", "rest-exporter");
 
         webClient.setAuthentication(context.getAuthenticationHeader());
-        getCookies(context.getAuthenticationHeader()).forEach(c -> webClient.addHeader(COOKIE_HEADER, c));
-        webClient.onSetCookieReceivedDo(this::handleNewCookie);
-        webClient.onSetCookieReceivedDo(c -> webClient.addHeader(COOKIE_HEADER, c));
+        manageCookies(webClient);
         return webClient;
+    }
+
+    private void manageCookies(WebClient webClient) {
+        synchronized (COOKIES) {
+            getCookies(context.getAuthenticationHeader()).forEach(c -> webClient.addHeader(COOKIE_HEADER, c));
+            webClient.onSetCookieReceivedDo(this::handleNewCookie);
+            webClient.onSetCookieReceivedDo(c -> webClient.addHeader(COOKIE_HEADER, c));
+        }
     }
 
     public List<String> getCookies(String credentials) {

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/SystemClock.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/SystemClock.java
@@ -1,0 +1,37 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.wls.exporter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * A wrapper for the system clock that facilitates unit testing of time.
+ */
+public abstract class SystemClock {
+
+  // Leave as non-final; unit tests may replace this value
+  @SuppressWarnings({"FieldMayBeFinal", "CanBeFinal"})
+  private static SystemClock delegate = new SystemClock() {
+    @Override
+    public OffsetDateTime getCurrentTime() {
+      return OffsetDateTime.now();
+    }
+  };
+
+  /**
+   * Returns the current time.
+   *
+   * @return a time instance
+   */
+  public static OffsetDateTime now() {
+    return delegate.getCurrentTime();
+  }
+
+  /**
+   * Returns the delegate's current time.
+   *
+   * @return a time instance
+   */
+  public abstract OffsetDateTime getCurrentTime();
+}

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebAppConstants.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebAppConstants.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
@@ -25,8 +25,17 @@ public interface WebAppConstants {
     String MESSAGES_PAGE = "messages";
     String LOG_PAGE = "log";
 
+    /** The header sent by a web server to require authentication. **/
+    String AUTHENTICATION_CHALLENGE_HEADER = "WWW-Authenticate";
+
+    /** The header used by a web server to define a new cookie. **/
+    String SET_COOKIE_HEADER = "Set-Cookie";
+
     /** The header used by a web client to send its authentication credentials. **/
     String AUTHENTICATION_HEADER = "Authorization";
+
+    /** The header used by a web client to pass a created cookie to a server. **/
+    String COOKIE_HEADER = "Cookie";
 
     /** The header used by a web client to specify the content type of its data. **/
     String CONTENT_TYPE_HEADER = "Content-Type";
@@ -35,7 +44,7 @@ public interface WebAppConstants {
     String EFFECT_OPTION = "effect";
 
     // The possible values for the effect
-    String DEFAULT_ACTION = WebAppConstants.REPLACE_ACTION;
     String REPLACE_ACTION = "replace";
     String APPEND_ACTION = "append";
+    String DEFAULT_ACTION = REPLACE_ACTION;
 }

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClient.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClient.java
@@ -1,9 +1,10 @@
-// Copyright (c) 2017, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 /**
  * An interface for an object responsible for sending requests from exporter web application to
@@ -72,4 +73,16 @@ public interface WebClient {
    * Returns true if this client has been marked to retry the last request.
    */
   boolean isRetryNeeded();
+
+  /**
+   * Defines a handler to be called when a Set-Cookie header is found in a reply from the server.
+   * @param setCookieHandler the handler to call with the value of the header
+   */
+  void onSetCookieReceivedDo(Consumer<String> setCookieHandler);
+
+
+  interface Response {
+    String getBody() throws IOException;
+
+  }
 }

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientCommon.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientCommon.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
@@ -11,11 +11,17 @@ import java.net.ConnectException;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.oracle.wls.exporter.WebAppConstants.AUTHENTICATION_CHALLENGE_HEADER;
 import static com.oracle.wls.exporter.WebAppConstants.AUTHENTICATION_HEADER;
 import static com.oracle.wls.exporter.WebAppConstants.CONTENT_TYPE_HEADER;
+import static com.oracle.wls.exporter.WebAppConstants.SET_COOKIE_HEADER;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
@@ -32,6 +38,7 @@ public abstract class WebClientCommon implements WebClient {
     private boolean retryNeeded;
     private String contentType;
     private String url;
+    private final List<Consumer<String>> setCookieHandlers = new ArrayList<>();
 
     interface WebRequest {
         String getMethod();
@@ -105,26 +112,26 @@ public abstract class WebClientCommon implements WebClient {
     @Override
     public String doGetRequest() throws IOException {
         defineSessionHeaders();
-        return sendRequest(createGetRequest(url));
+        return sendRequest(createGetRequest(url)).getBody();
     }
 
     @Override
     public String doPostRequest(String postBody) throws IOException {
         if (contentType == null) contentType = APPLICATION_JSON;
         defineSessionHeaders();
-        return sendRequest(createPostRequest(url, postBody));
+        return sendRequest(createPostRequest(url, postBody)).getBody();
     }
 
     @Override
     public <T> String doPutRequest(T putBody) throws IOException {
         defineSessionHeaders();
-        return sendRequest(createPutRequest(url, putBody));
+        return sendRequest(createPutRequest(url, putBody)).getBody();
     }
 
     // Sends the specified request to the server
-    private String sendRequest(WebRequest request) throws IOException {
+    private ResponseImpl sendRequest(WebRequest request) throws IOException {
         try (HttpClientExec clientExec = createClientExec()) {
-            return getReply(clientExec.send(request));
+            return new ResponseImpl(clientExec.send(request));
         } catch (UnknownHostException | ConnectException e) {
             throw new RestPortConnectionException(request.getURI().toString());
         } catch (GeneralSecurityException e) {
@@ -132,59 +139,10 @@ public abstract class WebClientCommon implements WebClient {
         }
     }
 
-    private String getReply(WebResponse response) throws IOException {
-        processStatusCode(response);
-        try (final InputStream contents = response.getContents()) {
-            return toString(contents);
-        }
-    }
-
-    private void processStatusCode(WebResponse response) {
-        switch (response.getResponseCode()) {
-            case HTTP_BAD_REQUEST:
-                throw new RestQueryException();
-            case HTTP_UNAUTHORIZED:
-                throw createAuthenticationChallengeException(response);
-            case HTTP_FORBIDDEN:
-                throw new ForbiddenException();
-            default:
-                if (response.getResponseCode() > SC_BAD_REQUEST)
-                    throw createServerErrorException(response);
-        }
-    }
-
-    private ServerErrorException createServerErrorException(WebResponse response) {
-        try {
-            return new ServerErrorException(response.getResponseCode(), toString(response.getContents()));
-        } catch (IOException e) {
-            return new ServerErrorException(response.getResponseCode());
-        }
-    }
-
-    // Converts an input stream to a string.
-    private String toString(InputStream inputStream) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        byte[] buffer = new byte[4096];
-        int numBytes = 0;
-        while (numBytes >= 0) {
-            baos.write(buffer, 0, numBytes);
-            numBytes = inputStream.read(buffer);
-        }
-        return baos.toString("UTF8");
-    }
-
     final void defineSessionHeaders() {
         clearSessionHeaders();
         if (getAuthentication() != null) putSessionHeader(AUTHENTICATION_HEADER, getAuthentication());
         if (getContentType() != null) putSessionHeader(CONTENT_TYPE_HEADER, getContentType());
-    }
-
-    private AuthenticationChallengeException createAuthenticationChallengeException(WebResponse response) {
-        return new AuthenticationChallengeException(getAuthenticationHeader(response));
-    }
-
-    private String getAuthenticationHeader(WebResponse response) {
-        return response.getHeadersAsStream("WWW-Authenticate").filter(Objects::nonNull).findFirst().orElse(null);
     }
 
     static class EmptyInputStream extends InputStream {
@@ -235,5 +193,84 @@ public abstract class WebClientCommon implements WebClient {
         } finally {
             retryNeeded = false;
         }
+    }
+
+    @Override
+    public void onSetCookieReceivedDo(Consumer<String> setCookieHandler) {
+        setCookieHandlers.add(setCookieHandler);
+    }
+
+    protected void invokeSetCookieHandlerCallbacks(List<String> setCookieHeaders) {
+        setCookieHandlers.forEach(setCookieHeaders::forEach);
+    }
+
+    class ResponseImpl implements WebClient.Response {
+        private final WebResponse response;
+        private final String body;
+
+        ResponseImpl(WebResponse response) throws IOException {
+            this.response = response;
+            processStatusCode();
+            reportSetCookieHeaders();
+
+            try (final InputStream contents = response.getContents()) {
+                body = asString(contents);
+            }
+        }
+
+        private void processStatusCode() {
+            switch (response.getResponseCode()) {
+                case HTTP_BAD_REQUEST:
+                    throw new RestQueryException();
+                case HTTP_UNAUTHORIZED:
+                    throw createAuthenticationChallengeException();
+                case HTTP_FORBIDDEN:
+                    throw new ForbiddenException();
+                default:
+                    if (response.getResponseCode() > SC_BAD_REQUEST)
+                        throw createServerErrorException();
+            }
+        }
+
+        private void reportSetCookieHeaders() {
+            invokeSetCookieHandlerCallbacks(getSetCookieHeaders());
+        }
+
+        private List<String> getSetCookieHeaders() {
+            return response.getHeadersAsStream(SET_COOKIE_HEADER).filter(Objects::nonNull).collect(Collectors.toList());
+        }
+
+        private ServerErrorException createServerErrorException() {
+            try {
+                return new ServerErrorException(response.getResponseCode(), asString(response.getContents()));
+            } catch (IOException e) {
+                return new ServerErrorException(response.getResponseCode());
+            }
+        }
+
+        private AuthenticationChallengeException createAuthenticationChallengeException() {
+            return new AuthenticationChallengeException(getAuthenticationHeader());
+        }
+
+        private String getAuthenticationHeader() {
+            return response.getHeadersAsStream(AUTHENTICATION_CHALLENGE_HEADER).filter(Objects::nonNull).findFirst().orElse(null);
+        }
+
+        private String asString(InputStream inputStream) throws IOException {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] buffer = new byte[4096];
+            int numBytes = 0;
+            while (numBytes >= 0) {
+                baos.write(buffer, 0, numBytes);
+                numBytes = inputStream.read(buffer);
+            }
+            return baos.toString("UTF8");
+        }
+
+        @Override
+        public String getBody() {
+            return body;
+        }
+
     }
 }

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/AuthenticatedCallTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/AuthenticatedCallTest.java
@@ -1,0 +1,135 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.wls.exporter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.meterware.simplestub.Memento;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.oracle.wls.exporter.InvocationContextStub.CREDENTIALS;
+import static com.oracle.wls.exporter.WebAppConstants.COOKIE_HEADER;
+import static com.oracle.wls.exporter.WebAppConstants.SET_COOKIE_HEADER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+
+class AuthenticatedCallTest {
+
+  private final WebClientFactoryStub webClientFactory = new WebClientFactoryStub();
+  private final InvocationContextStub invocationContext = InvocationContextStub.create();
+  private final AuthenticatedCallStub callStub = new AuthenticatedCallStub(webClientFactory, invocationContext);
+  private final List<Memento> mementos = new ArrayList<>();
+
+  @BeforeEach
+  void setUp() throws NoSuchFieldException {
+    AuthenticatedCall.clearCookies();
+
+    mementos.add(SystemClockTestSupport.installClock());
+  }
+
+  @AfterEach
+  void tearDown() {
+    mementos.forEach(Memento::revert);
+  }
+
+  @Test
+  void whenInvocationContextContainsNoCookieHeaders_callToServerContinues() throws IOException {
+
+    callStub.doWithAuthentication();
+
+    assertThat(webClientFactory.getSentHeaders(COOKIE_HEADER), empty());
+  }
+
+  @Test
+  void withNoAuthenticationWhenResponseFromRestApiContainsSetCookieHeaders_ignoreThem() throws IOException {
+    invocationContext.setAuthenticationHeader(null);
+    configureResponseWithSetCookieHeaders();
+
+    callStub.doWithAuthentication();
+
+    assertThat(callStub.getCookies(CREDENTIALS), empty());
+  }
+
+  private void configureResponseWithSetCookieHeaders() {
+    webClientFactory.forJson("{}")
+          .withResponseHeader(SET_COOKIE_HEADER, "cookie1=value1; http-only")
+          .withResponseHeader(SET_COOKIE_HEADER, "cookie2=value2; secure")
+          .addResponse();
+  }
+
+  @Test 
+  void whenResponseFromRestApiContainsSetCookieHeaders_cacheThem() throws IOException {
+    configureResponseWithSetCookieHeaders();
+
+    callStub.doWithAuthentication();
+
+    assertThat(callStub.getCookies(CREDENTIALS), containsInAnyOrder("cookie1=value1", "cookie2=value2"));
+  }
+
+  @Test
+  void whenResponseFromRestApiContainsSetCookieHeaders_ignoreForDifferentCredentials() throws IOException {
+    configureResponseWithSetCookieHeaders();
+
+    callStub.doWithAuthentication();
+
+    assertThat(callStub.getCookies("other credentials"), empty());
+  }
+
+  @Test
+  void whenInvocationContextContainsCookieHeaders_forwardThemToTheServer() throws IOException {
+    callStub.handleNewCookie("cookie1=value1; http-only");
+    callStub.handleNewCookie("cookie2=value2; secure");
+    webClientFactory.forJson("{}").addResponse();
+    
+    callStub.doWithAuthentication();
+
+    final List<String> cookieHeaders
+          = webClientFactory.getSentHeaders(COOKIE_HEADER).stream()
+          .map(this::trimParameters)
+          .collect(Collectors.toList());
+    assertThat(cookieHeaders, containsInAnyOrder("cookie1=value1", "cookie2=value2"));
+  }
+
+  @Test
+  void wheCookiesExpired_removeThem() throws IOException {
+    callStub.handleNewCookie("cookie1=value1; http-only");
+    callStub.handleNewCookie("cookie2=value2; secure");
+    webClientFactory.forJson("{}").addResponse();
+
+    SystemClockTestSupport.increment(AuthenticatedCall.COOKIE_LIFETIME_SECONDS + 1);
+    callStub.doWithAuthentication();
+
+    final List<String> cookieHeaders
+          = webClientFactory.getSentHeaders(COOKIE_HEADER).stream()
+          .map(this::trimParameters)
+          .collect(Collectors.toList());
+    assertThat(cookieHeaders, empty());
+  }
+
+  private String trimParameters(String cookieHeader) {
+    if (!cookieHeader.contains(";"))
+      return cookieHeader;
+    else
+      return cookieHeader.substring(0, cookieHeader.indexOf(';'));
+  }
+
+  static class AuthenticatedCallStub extends AuthenticatedCall {
+    AuthenticatedCallStub(WebClientFactory webClientFactory, InvocationContext context) {
+      super(webClientFactory, context);
+    }
+
+    @Override
+    protected void invoke(WebClient webClient, InvocationContext context) throws IOException {
+      webClient.withUrl(getAuthenticationUrl()).doPostRequest("abcd");
+    }
+  }
+
+
+}

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ConfigurationFormCallTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ConfigurationFormCallTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import static com.oracle.wls.exporter.InvocationContextStub.HOST_NAME;
 import static com.oracle.wls.exporter.InvocationContextStub.PORT;
 import static com.oracle.wls.exporter.InvocationContextStub.REST_PORT;
+import static com.oracle.wls.exporter.WebAppConstants.AUTHENTICATION_CHALLENGE_HEADER;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -184,6 +185,6 @@ class ConfigurationFormCallTest {
     handleConfigurationFormCall(context.withConfigurationForm("replace", CONFIGURATION));
 
     assertThat(context.getResponseStatus(), equalTo(HTTP_UNAUTHORIZED));
-    assertThat(context.getResponseHeader("WWW-Authenticate"), equalTo("Basic realm=\"Test-Realm\""));
+    assertThat(context.getResponseHeader(AUTHENTICATION_CHALLENGE_HEADER), equalTo("Basic realm=\"Test-Realm\""));
   }
 }

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ExporterCallTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ExporterCallTest.java
@@ -1,16 +1,19 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
 
 import java.io.IOException;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.oracle.wls.exporter.InvocationContextStub.HOST_NAME;
 import static com.oracle.wls.exporter.InvocationContextStub.PORT;
+import static com.oracle.wls.exporter.WebAppConstants.COOKIE_HEADER;
+import static com.oracle.wls.exporter.WebAppConstants.SET_COOKIE_HEADER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -22,11 +25,25 @@ class ExporterCallTest {
   private static final String ONE_VALUE_CONFIG = "queries:\n- groups:\n    key: name\n    values: testSample1";
   private static final String CONFIG_WITH_FILTER = "queries:" +
         "\n- groups:\n    key: name\n    includedKeyValues: abc.*\n    values: testSample1";
+  private static final String DUAL_QUERY_CONFIG = ONE_VALUE_CONFIG +
+        "\n- clubs:\n    key: name\n    values: testSample2";
 
   private static final String KEY_RESPONSE_JSON = "{\"groups\": {\"items\": [\n" +
               "     {\"name\": \"alpha\"},\n" +
               "     {\"name\": \"beta\" },\n" +
               "     {\"name\": \"gamma\"}\n" +
+              "]}}";
+
+  private static final String QUERY_RESPONSE1_JSON = "{\"groups\": {\"items\": [\n" +
+              "     {\"name\": \"alpha\", \"testSample1\": \"first\"},\n" +
+              "     {\"name\": \"beta\", \"testSample1\": \"second\"},\n" +
+              "     {\"name\": \"gamma\", \"testSample1\": \"third\"}\n" +
+              "]}}";
+
+  private static final String QUERY_RESPONSE2_JSON = "{\"clubs\": {\"items\": [\n" +
+              "     {\"name\": \"aleph\", \"testSample2\": \"first\"},\n" +
+              "     {\"name\": \"bet\", \"testSample2\": \"second\"},\n" +
+              "     {\"name\": \"gimel\", \"testSample2\": \"third\"}\n" +
               "]}}";
 
   private final WebClientFactoryStub factory = new WebClientFactoryStub();
@@ -35,6 +52,7 @@ class ExporterCallTest {
   @BeforeEach
   public void setUp() {
     LiveConfiguration.setServer(HOST_NAME, PORT);
+    AuthenticatedCall.clearCookies();
   }
 
   @Test
@@ -97,5 +115,16 @@ class ExporterCallTest {
     handleMetricsCall(context.withHttps());
 
     assertThat(factory.getNumQueriesSent(), equalTo(2));
+  }
+
+  @Test
+  void whenHaveMultipleQueries_sendServerDefinedCookieOnSecondQuery() throws IOException {
+    factory.forJson(QUERY_RESPONSE1_JSON).withResponseHeader(SET_COOKIE_HEADER, "cookieName=newValue").addResponse();
+    factory.addJsonResponse(QUERY_RESPONSE2_JSON);
+    LiveConfiguration.loadFromString(DUAL_QUERY_CONFIG);
+
+    handleMetricsCall(context);
+
+    assertThat(factory.getSentHeaders(COOKIE_HEADER), Matchers.hasItem("cookieName=newValue"));
   }
 }

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ExporterServletTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ExporterServletTest.java
@@ -1,14 +1,14 @@
-// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
 
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
 
 import com.google.common.collect.ImmutableMap;
 import com.oracle.wls.exporter.webapp.ExporterServlet;
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.oracle.wls.exporter.InMemoryFileSystem.withNoParams;
+import static com.oracle.wls.exporter.WebAppConstants.AUTHENTICATION_CHALLENGE_HEADER;
 import static com.oracle.wls.exporter.WebAppConstants.AUTHENTICATION_HEADER;
 import static com.oracle.wls.exporter.matchers.CommentsOnlyMatcher.containsOnlyComments;
 import static com.oracle.wls.exporter.matchers.MetricsNamesSnakeCaseMatcher.usesSnakeCase;
@@ -37,7 +38,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -213,7 +213,7 @@ class ExporterServletTest {
         servlet.doGet(request, response);
 
         assertThat(response.getStatus(), equalTo(SC_UNAUTHORIZED));
-        assertThat(response, containsHeader("WWW-Authenticate", "Basic realm=\"Test-Realm\""));
+        assertThat(response, containsHeader(AUTHENTICATION_CHALLENGE_HEADER, "Basic realm=\"Test-Realm\""));
     }
 
     @Test
@@ -256,7 +256,7 @@ class ExporterServletTest {
 
         servlet.doGet(request, response);
 
-        assertThat(factory.getSentHeaders(), hasKey("X-Requested-By"));
+        assertThat(factory.getSentHeaders("X-Requested-By"), not(empty()));
     }
 
     @Test

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/SystemClockTestSupport.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/SystemClockTestSupport.java
@@ -1,0 +1,42 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.wls.exporter;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+
+import com.meterware.simplestub.Memento;
+import com.meterware.simplestub.StaticStubSupport;
+
+public class SystemClockTestSupport {
+  private static TestSystemClock clock;
+
+  public static Memento installClock() throws NoSuchFieldException {
+    clock = new TestSystemClock();
+    return StaticStubSupport.install(SystemClock.class, "delegate", clock);
+  }
+
+  /**
+   * Increments the system clock by the specified number of seconds.
+   * @param numSeconds the number of seconds by which to advance the system clock
+   */
+  public static void increment(long numSeconds) {
+    clock.increment(numSeconds);
+  }
+
+  static class TestSystemClock extends SystemClock {
+    private final OffsetDateTime testStartTime = SystemClock.now().truncatedTo(ChronoUnit.SECONDS);
+    private OffsetDateTime currentTime = testStartTime;
+
+    @Override
+    public OffsetDateTime getCurrentTime() {
+      return currentTime;
+    }
+
+    void increment(long numSeconds) {
+      currentTime = currentTime.plusSeconds(numSeconds);
+    }
+  }
+
+}

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClientFactoryStub.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/WebClientFactoryStub.java
@@ -1,19 +1,20 @@
-// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import com.google.gson.Gson;
 
 import static com.meterware.simplestub.Stub.createStrictStub;
+import static com.oracle.wls.exporter.WebAppConstants.SET_COOKIE_HEADER;
 
 public class WebClientFactoryStub implements WebClientFactory {
     private final WebClientStub webClient = createStrictStub(WebClientStub.class);
@@ -25,12 +26,21 @@ public class WebClientFactoryStub implements WebClientFactory {
         return webClient;
     }
 
+    interface ResponseBuilder {
+        ResponseBuilder withResponseHeader(String name, String value);
+        void addResponse();
+    }
+
     void addJsonResponse(Map<String, Object> responseMap) {
         webClient.addJsonResponse(new Gson().toJson(responseMap));
     }
 
     void addJsonResponse(String json) {
         webClient.addJsonResponse(json);
+    }
+
+    ResponseBuilder forJson(String json) {
+        return webClient.forJson(json);
     }
 
     int getNumQueriesSent() {
@@ -49,8 +59,8 @@ public class WebClientFactoryStub implements WebClientFactory {
         return webClient.postedString;
     }
 
-    Map<String,String> getSentHeaders() {
-        return webClient.sentHeaders;
+    List<String> getSentHeaders(String headerName) {
+        return Optional.ofNullable(webClient.sentHeaders.get(headerName)).orElse(Collections.emptyList());
     }
 
     String getSentAuthentication() {
@@ -90,17 +100,41 @@ public class WebClientFactoryStub implements WebClientFactory {
         private final List<String> jsonQueries = new ArrayList<>();
         private final List<TestResponse> testResponses = new ArrayList<>();
         private Iterator<TestResponse> responses;
-        private final Map<String, String> addedHeaders = new HashMap<>();
-        private Map<String, String> sentHeaders;
+        private final Map<String, List<String>> addedHeaders = new HashMap<>();
+        private Map<String, List<String>> sentHeaders;
         private String postedString;
 
-        private void addJsonResponse(String jsonResponse) {
-            addResponse(new JsonResponse(jsonResponse));
+        private void addJsonResponse(String responseJson) {
+            addResponse(new JsonResponse(responseJson));
         }
 
         private void addResponse(TestResponse response) {
             if (allResponsesHandled()) clearOldResponses();
             testResponses.add(response);
+        }
+
+        private ResponseBuilder forJson(String jsonString) {
+            return new ResponseBuilderImpl(jsonString);
+        }
+
+        class ResponseBuilderImpl implements ResponseBuilder {
+            private final JsonResponse jsonResponse;
+
+            ResponseBuilderImpl(String jsonString) {
+                this.jsonResponse = new JsonResponse(jsonString);
+                WebClientStub.this.addedHeaders.clear();
+            }
+
+            @Override
+            public ResponseBuilder withResponseHeader(String name, String value) {
+                jsonResponse.withResponseHeader(name, value);
+                return this;
+            }
+
+            @Override
+            public void addResponse() {
+                WebClientStub.this.addResponse(jsonResponse);
+            }
         }
 
         private boolean allResponsesHandled() {
@@ -130,7 +164,7 @@ public class WebClientFactoryStub implements WebClientFactory {
         }
 
         void throwConnectionFailure(String hostName, int port) {
-            addExceptionResponse(new RestPortConnectionException(String.format("http://%s:%d", hostName, port)));
+            addExceptionResponse(new RestPortConnectionException(String.format("https://%s:%d", hostName, port)));
         }
 
         @Override
@@ -141,7 +175,7 @@ public class WebClientFactoryStub implements WebClientFactory {
 
         @Override
         public void addHeader(String name, String value) {
-            addedHeaders.put(name, value);
+            addedHeaders.computeIfAbsent(name, n -> new ArrayList<>()).add(value);
         }
 
         @Override
@@ -162,7 +196,7 @@ public class WebClientFactoryStub implements WebClientFactory {
         }
 
         @Override
-        public <T> String doPutRequest(T putBody) throws IOException {
+        public <T> String doPutRequest(T putBody) {
             if (url == null) throw new NullPointerException("No URL specified");
             postedString = new Gson().toJson(putBody);
 
@@ -176,7 +210,13 @@ public class WebClientFactoryStub implements WebClientFactory {
 
         private String getResult(TestResponse response) {
             if (response.getException() != null) throw response.getException();
+
+            invokeSetCookieHandlerCallbacks(getSetCookieHeaders(response));
             return response.getJsonResponse();
+        }
+
+        private List<String> getSetCookieHeaders(TestResponse response) {
+            return response.getResponseHeaders(SET_COOKIE_HEADER);
         }
 
     }
@@ -184,6 +224,7 @@ public class WebClientFactoryStub implements WebClientFactory {
     interface TestResponse {
         WebClientException getException();
         String getJsonResponse();
+        List<String> getResponseHeaders(String headerName);
     }
 
     static class ExceptionResponse implements TestResponse {
@@ -202,13 +243,24 @@ public class WebClientFactoryStub implements WebClientFactory {
         public String getJsonResponse() {
             return null;
         }
+
+        @Override
+        public List<String> getResponseHeaders(String headerName) {
+            return Collections.emptyList();
+        }
     }
 
     static class JsonResponse implements TestResponse {
         String jsonResponse;
+        private final Map<String, List<String>> responseHeaders = new HashMap<>();
 
         JsonResponse(String jsonResponse) {
             this.jsonResponse = jsonResponse;
+        }
+
+        JsonResponse withResponseHeader(String name, String value) {
+            getResponseHeaders(name).add(value);
+            return this;
         }
 
         @Override
@@ -220,11 +272,11 @@ public class WebClientFactoryStub implements WebClientFactory {
         public String getJsonResponse() {
             return jsonResponse;
         }
-    }
 
-    static class QueryTestException extends WebClientException {
-        public QueryTestException(String message) {
-            super(message);
+        @Override
+        public List<String> getResponseHeaders(String headerName) {
+            return responseHeaders.computeIfAbsent(headerName, k -> new ArrayList<>());
         }
     }
+
 }

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/webapp/ConfigurationServletTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/webapp/ConfigurationServletTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter.webapp;
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.oracle.wls.exporter.MultipartTestUtils.createEncodedForm;
 import static com.oracle.wls.exporter.MultipartTestUtils.createUploadRequest;
+import static com.oracle.wls.exporter.WebAppConstants.AUTHENTICATION_CHALLENGE_HEADER;
 import static com.oracle.wls.exporter.WebAppConstants.CONFIGURATION_PAGE;
 import static com.oracle.wls.exporter.matchers.ResponseHeaderMatcher.containsHeader;
 import static com.oracle.wls.exporter.webapp.HttpServletRequestStub.LOCAL_PORT;
@@ -244,6 +245,6 @@ class ConfigurationServletTest {
         servlet.doPost(request, response);
 
         assertThat(response.getStatus(), equalTo(SC_UNAUTHORIZED));
-        assertThat(response, containsHeader("WWW-Authenticate", "Basic realm=\"Test-Realm\""));
+        assertThat(response, containsHeader(AUTHENTICATION_CHALLENGE_HEADER, "Basic realm=\"Test-Realm\""));
     }
 }

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/webapp/HttpServletRequestStub.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/webapp/HttpServletRequestStub.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter.webapp;
@@ -7,12 +7,15 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 import javax.servlet.ServletInputStream;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
@@ -36,8 +39,9 @@ public abstract class HttpServletRequestStub implements HttpServletRequest {
     private int localPort = LOCAL_PORT;
     private String contentType = DEFAULT_CONTENT_TYPE;
     private String contents;
-    private ServletInputStream inputStream;
+    private List<Cookie> cookies = null;
     private String contextPath;
+    private ServletInputStream inputStream;
     private String servletPath = "";
     private HttpSessionStub session;
     private boolean secure;
@@ -111,6 +115,11 @@ public abstract class HttpServletRequestStub implements HttpServletRequest {
     @Override
     public String getContentType() {
         return contentType;
+    }
+
+    @Override
+    public Cookie[] getCookies() {
+        return cookies == null ? null : cookies.toArray(new Cookie[0]);
     }
 
     @Override
@@ -191,6 +200,11 @@ public abstract class HttpServletRequestStub implements HttpServletRequest {
 
     public boolean hasInvalidatedSession() {
         return session != null && !session.valid;
+    }
+
+    public void addCookie(String name, String value) {
+        if (cookies == null) cookies = new ArrayList<>();
+        cookies.add(new Cookie(name, value));
     }
 
     static abstract class HttpSessionStub implements HttpSession {

--- a/wls-exporter-sidecar/src/test/java/com/oracle/wls/exporter/sidecar/HelidonInvocationContextTest.java
+++ b/wls-exporter-sidecar/src/test/java/com/oracle/wls/exporter/sidecar/HelidonInvocationContextTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter.sidecar;
@@ -107,11 +107,11 @@ class HelidonInvocationContextTest {
 
   abstract static class RequestHeadersStub implements RequestHeaders {
 
-    private final Map<String, String> headers = new HashMap<>();
+    private final Map<String, List<String>> headers = new HashMap<>();
     private MediaType contentType;
 
     void addHeader(String name, String value) {
-      headers.put(name, value);
+      all(name).add(value);
     }
 
     void setContentType(MediaType contentType) {
@@ -120,7 +120,12 @@ class HelidonInvocationContextTest {
 
     @Override
     public Optional<String> first(String name) {
-      return Optional.ofNullable(headers.get(name));
+      return Optional.ofNullable(headers.get(name)).map(l->l.get(0));
+    }
+
+    @Override
+    public List<String> all(String name) {
+      return headers.computeIfAbsent(name, k -> new ArrayList<>());
     }
 
     @Override

--- a/wls-exporter-sidecar/src/test/java/com/oracle/wls/exporter/sidecar/MetricsServiceTest.java
+++ b/wls-exporter-sidecar/src/test/java/com/oracle/wls/exporter/sidecar/MetricsServiceTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter.sidecar;
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.meterware.simplestub.Stub.createStub;
+import static com.oracle.wls.exporter.WebAppConstants.AUTHENTICATION_CHALLENGE_HEADER;
 import static com.oracle.wls.exporter.WebAppConstants.AUTHENTICATION_HEADER;
 import static com.oracle.wls.exporter.domain.QueryType.RUNTIME_URL_PATTERN;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
@@ -151,11 +152,11 @@ class MetricsServiceTest {
         final TestResponse metricsResponse = getMetricsResponse();
 
         assertThat(metricsResponse.status().code(), equalTo(HTTP_UNAUTHORIZED));
-        assertThat(getAuthenticationHeader(metricsResponse), equalTo("Basic realm=\"Test-Realm\""));
+        assertThat(getAuthenticationChallengeHeader(metricsResponse), equalTo("Basic realm=\"Test-Realm\""));
     }
 
-    private String getAuthenticationHeader(TestResponse metricsResponse) {
-        return metricsResponse.headers().first("WWW-Authenticate").orElse(null);
+    private String getAuthenticationChallengeHeader(TestResponse metricsResponse) {
+        return metricsResponse.headers().first(AUTHENTICATION_CHALLENGE_HEADER).orElse(null);
     }
 
     @Test

--- a/wls-exporter-war/src/main/webapp/WEB-INF/weblogic.xml
+++ b/wls-exporter-war/src/main/webapp/WEB-INF/weblogic.xml
@@ -1,0 +1,10 @@
+<!--
+    Copyright (c) 2023, Oracle and/or its affiliates.
+    Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+-->
+<weblogic-web-app xmlns="http://xmlns.oracle.com/weblogic/weblogic-web-app">
+<session-descriptor>
+    <tracking-enabled>false</tracking-enabled>
+  </session-descriptor>
+
+</weblogic-web-app>


### PR DESCRIPTION
The REST API creates sessions when it receives a request specifying login credentials; in order to prevent it from creating massive numbers of them, the exporter now acts as a web browser does, adding to its collection of web cookies when it receives a Set-Cookie header from the REST API, and sending a Cookie header to the API when it makes requests.