### PR TITLE
Improve filtering: ignore subtrees with no matches, exclude forbidden…

### DIFF
--- a/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/GitTagMojo.java
+++ b/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/GitTagMojo.java
@@ -1,13 +1,7 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.buildhelper;
-
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,6 +10,12 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 @Mojo(name = "gitVersion", defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
 public class GitTagMojo extends AbstractMojo {
@@ -61,7 +61,7 @@ public class GitTagMojo extends AbstractMojo {
   }
 
   private String formatVersionString(String[] segments) {
-    final String commit = segments[segments.length - 1];
+    final String commit = segments[segments.length - 1].substring(1);
     final String numCommits = segments[segments.length - 2];
     final String versionParts = String.join("-", Arrays.copyOfRange(segments, 0, segments.length - 2));
     return formatVersionString(commit, numCommits, versionParts);

--- a/build-helper-mojo/src/test/java/com/oracle/wls/buildhelper/GitTagMojoTest.java
+++ b/build-helper-mojo/src/test/java/com/oracle/wls/buildhelper/GitTagMojoTest.java
@@ -1,7 +1,12 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.buildhelper;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -9,13 +14,12 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.lang.reflect.Field;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class GitTagMojoTest {
@@ -88,7 +92,7 @@ class GitTagMojoTest {
     mojo.execute();
 
     assertThat(inMemoryFileSystem.getContents(outputFile.getAbsolutePath()),
-          containsString("version=gcb4385f3aa (946 commits since v3.3.5-3)"));
+          containsString("version=cb4385f3aa (946 commits since v3.3.5-3)"));
   }
 
   @Test

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/ExporterCall.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/ExporterCall.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
@@ -52,15 +52,26 @@ public class ExporterCall extends AuthenticatedCall {
       if (!metrics.isEmpty())
         sort(metrics).forEach(metricsStream::printMetric);
     } catch (RestQueryException e) {
-      metricsStream.println(
-            withCommentMarkers("REST service was unable to handle this query and returned a " + HTTP_BAD_REQUEST + "\n"
-                  + selector.getPrintableRequest()));
+      reportProblem(metricsStream, selector);
     } catch (AuthenticationChallengeException e) {  // don't add a message for this case
       throw e;
     } catch (IOException | RuntimeException e) {
       WlsRestExchanges.addExchange(getQueryUrl(selector), selector.getRequest(), e.toString());
       throw e;
     }
+  }
+
+  private void reportProblem(MetricsStream metricsStream, MBeanSelector selector) {
+    metricsStream.println(withCommentMarkers(getProblem(selector) + "\n" + selector.getPrintableRequest()));
+  }
+
+  private String getProblem(MBeanSelector selector) {
+    if (selector.isRequestForPrivilegedProperty())
+      return "You seem to have encountered a bug in the WebLogic REST API.\n" +
+            " The JDBCServiceRuntime.JDBCDataSourceRuntimeMBeans.properties property " +
+            " may only be accessed by a user with administrator privileges.";
+    else
+      return "REST service was unable to handle this query and returned a " + HTTP_BAD_REQUEST;
   }
 
   private static String withCommentMarkers(String string) {

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientCommon.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WebClientCommon.java
@@ -25,7 +25,6 @@ import static com.oracle.wls.exporter.WebAppConstants.SET_COOKIE_HEADER;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
-import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 
 /**
  * A client for sending http requests.  Note that it does not do any authentication by itself.
@@ -227,7 +226,7 @@ public abstract class WebClientCommon implements WebClient {
                 case HTTP_FORBIDDEN:
                     throw new ForbiddenException();
                 default:
-                    if (response.getResponseCode() > SC_BAD_REQUEST)
+                    if (response.getResponseCode() > HTTP_BAD_REQUEST)
                         throw createServerErrorException();
             }
         }

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/ExporterConfig.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/ExporterConfig.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter.domain;
@@ -24,6 +24,10 @@ import org.yaml.snakeyaml.scanner.ScannerException;
  * @author Russell Gold
  */
 public class ExporterConfig implements MetricsProcessor {
+    // Due to a bug in the WLS REST API, a query that includes this field will fail if not run with admin privileges.
+    // The code thus ensures that it is excluded from all queries.
+    private static final String[] FORBIDDEN_FIELDS = {"JDBCServiceRuntime:JDBCDataSourceRuntimeMBeans:properties"};
+
     public static final String DOMAIN_NAME_PROPERTY = "DOMAIN";
 
     private static final String QUERY_SYNC = "query_sync";
@@ -173,7 +177,7 @@ public class ExporterConfig implements MetricsProcessor {
 
     private void appendQueries(Object queriesYaml) {
         for (Map<String,Object> selectorSpec : getAsListOfMaps(queriesYaml)) {
-            appendQuery(MBeanSelector.create(selectorSpec));
+            appendQuery(MBeanSelector.create(selectorSpec).withForbiddenFields(FORBIDDEN_FIELDS));
         }
     }
 

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/JsonQuerySpec.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/JsonQuerySpec.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import com.google.gson.Gson;
@@ -29,18 +30,13 @@ class JsonQuerySpec {
     private List<String> selectedKeys = null;
     private List<String> excludeFields = null;
 
-    JsonQuerySpec asTopLevel() {
-        addFields();
-        return this;
-    }
-
     /**
      * Specifies the name of any mbean values which should be retrieved.
      * @param newFields the field names to add to any previous defined
      */
     void addFields(String... newFields) {
         if (fields == null) fields = new ArrayList<>();
-        fields.addAll(Arrays.asList(newFields));
+        Arrays.stream(newFields).filter(Objects::nonNull).forEach(fields::add);
     }
 
     /**

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/JsonQuerySpec.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/JsonQuerySpec.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2020, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter.domain;
@@ -27,6 +27,12 @@ class JsonQuerySpec {
     private Map<String, JsonQuerySpec> children = null;
     private String keyName = null;
     private List<String> selectedKeys = null;
+    private List<String> excludeFields = null;
+
+    JsonQuerySpec asTopLevel() {
+        addFields();
+        return this;
+    }
 
     /**
      * Specifies the name of any mbean values which should be retrieved.
@@ -62,6 +68,7 @@ class JsonQuerySpec {
         
         result.add("links", new JsonArray());
         if (fields != null) result.add("fields", asStringArray(fields));
+        if (excludeFields != null) result.add("excludeFields", asStringArray(excludeFields));
         if (keyName != null) result.add(keyName, asStringArray(selectedKeys));
         if (children != null) asChildObject(result);
 
@@ -80,5 +87,10 @@ class JsonQuerySpec {
         for (Map.Entry<String, JsonQuerySpec> entry : children.entrySet()) {
             nesting.add(entry.getKey(), entry.getValue().toJsonObject());
         }
+    }
+
+    public void excludeField(String fieldName) {
+        if (excludeFields == null) excludeFields = new ArrayList<>();
+        excludeFields.add(fieldName);
     }
 }

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MBeanSelector.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MBeanSelector.java
@@ -350,7 +350,7 @@ public class MBeanSelector {
      * @return a JSON string
      */
     public String getRequest() {
-        return toQuerySpec().asTopLevel().toJson(new Gson());
+        return toQuerySpec().toJson(new Gson());
     }
 
     JsonQuerySpec toQuerySpec() {

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/DemoInputs.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/DemoInputs.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ExporterCallTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ExporterCallTest.java
@@ -25,6 +25,10 @@ class ExporterCallTest {
   private static final String ONE_VALUE_CONFIG = "queries:\n- groups:\n    key: name\n    values: testSample1";
   private static final String CONFIG_WITH_FILTER = "queries:" +
         "\n- groups:\n    key: name\n    includedKeyValues: abc.*\n    values: testSample1";
+  private static final String REQUEST_FOR_PRIVILEGED_PROPERTY = "queries:" +
+        "\n- JDBCServiceRuntime:\n    JDBCDataSourceRuntimeMBeans:\n      key: name\n      values: properties";
+  private static final String REQUEST_INCLUDES_PRIVILEGED_PROPERTY = "queries:" +
+        "\n- JDBCServiceRuntime:\n    JDBCDataSourceRuntimeMBeans:\n      prefix: ds_\n      key: name\n";
   private static final String DUAL_QUERY_CONFIG = ONE_VALUE_CONFIG +
         "\n- clubs:\n    key: name\n    values: testSample2";
 
@@ -115,6 +119,26 @@ class ExporterCallTest {
     handleMetricsCall(context.withHttps());
 
     assertThat(factory.getNumQueriesSent(), equalTo(2));
+  }
+
+  @Test
+  void whenBadQueryReceivedAndConfigurationSelectsPrivilegedPropertiesProperty_explainProblem() throws IOException {
+    factory.reportBadQuery();
+    LiveConfiguration.loadFromString(REQUEST_FOR_PRIVILEGED_PROPERTY);
+
+    handleMetricsCall(context.withHttps());
+
+    assertThat(context.getResponse(), containsString("bug in the WebLogic REST API"));
+  }
+
+  @Test
+  void whenBadQueryReceivedAndConfigurationSelectsPropertiesIncludingPrivilegedProperty_explainProblem() throws IOException {
+    factory.reportBadQuery();
+    LiveConfiguration.loadFromString(REQUEST_INCLUDES_PRIVILEGED_PROPERTY);
+
+    handleMetricsCall(context.withHttps());
+
+    assertThat(context.getResponse(), containsString("bug in the WebLogic REST API"));
   }
 
   @Test

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MBeanSelectorTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MBeanSelectorTest.java
@@ -231,19 +231,11 @@ class MBeanSelectorTest {
     }
 
     @Test
-    void whenTopLevelSelectorHasNoFields_fieldsListIsEmpty() {
-        MBeanSelector selector = MBeanSelector.create(ImmutableMap.of("servlets",
-                ImmutableMap.of(MBeanSelector.VALUES_KEY, new String[] {"first", "second"})));
-
-        assertThat(querySpec(selector), hasJsonPath("$.fields", hasSize(0)));
-    }
-
-    @Test
-    void whenTopLevelSelectorHasPrefixAndNoFields_fieldsListIsEmpty() {
+    void whenTopLevelSelectorHasPrefixAndNoFields_dontRequestFields() {
         MBeanSelector selector = MBeanSelector.create(ImmutableMap.of(MBeanSelector.PREFIX_KEY, "top_", "servlets",
                 ImmutableMap.of(MBeanSelector.VALUES_KEY, new String[] {"first", "second"})));
 
-        assertThat(querySpec(selector), hasJsonPath("$.fields", hasSize(0)));
+        assertThat(querySpec(selector), hasNoJsonPath("$.fields"));
     }
 
     @Test

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MBeanSelectorTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MBeanSelectorTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter.domain;
@@ -36,6 +36,7 @@ import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -223,6 +224,68 @@ class MBeanSelectorTest {
     }
 
     @Test
+    void whenTopLevelSelectorHasFields_isIncludedInQuery() {
+        MBeanSelector selector = MBeanSelector.create(ImmutableMap.of(MBeanSelector.VALUES_KEY, "sequence"));
+
+        assertThat(querySpec(selector), hasJsonPath("$.fields", contains("sequence")));
+    }
+
+    @Test
+    void whenTopLevelSelectorHasNoFields_fieldsListIsEmpty() {
+        MBeanSelector selector = MBeanSelector.create(ImmutableMap.of("servlets",
+                ImmutableMap.of(MBeanSelector.VALUES_KEY, new String[] {"first", "second"})));
+
+        assertThat(querySpec(selector), hasJsonPath("$.fields", hasSize(0)));
+    }
+
+    @Test
+    void whenTopLevelSelectorHasPrefixAndNoFields_fieldsListIsEmpty() {
+        MBeanSelector selector = MBeanSelector.create(ImmutableMap.of(MBeanSelector.PREFIX_KEY, "top_", "servlets",
+                ImmutableMap.of(MBeanSelector.VALUES_KEY, new String[] {"first", "second"})));
+
+        assertThat(querySpec(selector), hasJsonPath("$.fields", hasSize(0)));
+    }
+
+    @Test
+    void whenSelectorHasForbiddenFieldLeaf_querySpecListsItAsExcluded() {
+        MBeanSelector selector = MBeanSelector.create(ImmutableMap.of(MBeanSelector.PREFIX_KEY, "top_")).withForbiddenFields("bottom");
+
+        assertThat(querySpec(selector), hasJsonPath("$.excludeFields", contains("bottom")));
+    }
+
+    @Test
+    void whenSelectorExplicitlyIncludesForbiddenField_querySpecExcludesItFromList() {
+        MBeanSelector selector = MBeanSelector.create(
+              ImmutableMap.of(MBeanSelector.VALUES_KEY, new String[] {"top", "middle", "bottom"})).withForbiddenFields("bottom");
+
+        assertThat(querySpec(selector), hasJsonPath("$.fields", containsInAnyOrder("top", "middle")));
+        assertThat(querySpec(selector), hasNoJsonPath("$.excludeFields"));
+    }
+
+    @Test
+    void whenSelectorHasNestedForbiddenField_querySpecListsItAsExcluded() {
+        MBeanSelector selector = MBeanSelector.create(DEEP_MAP).withForbiddenFields("groups:middle:subgroup1:bottom");
+
+        assertThat(querySpec(selector),
+              hasJsonPath("$.children.groups.children.middle.children.subgroup1.excludeFields", contains("bottom")));
+    }
+
+    private static final Map<String, Object> DEEP_MAP = ImmutableMap.of("groups",
+        ImmutableMap.of(MBeanSelector.QUERY_KEY, "groupName",
+            "middle", ImmutableMap.of(
+                "subgroup1", ImmutableMap.of(MBeanSelector.KEY_NAME, "name", MBeanSelector.PREFIX_KEY, "sub1_"),
+                "subgroup2", ImmutableMap.of(MBeanSelector.PREFIX_KEY, "sub2_", MBeanSelector.VALUES_KEY, "val2" ))));
+
+
+    @Test
+    void whenSelectorHasAttempedNestingDeeperThanForbiddenLeaf_ignoreIt() {
+        MBeanSelector selector = MBeanSelector.create(DEEP_MAP).withForbiddenFields("groups:middle");
+
+        assertThat(querySpec(selector),
+              hasJsonPath("$.children.groups.children.middle.children.subgroup2.fields", contains("val2")));
+    }
+
+    @Test
     void whenIncludedKeysSpecifiedWithoutKeyName_report() {
         final Map<String, Object> BAD_MAP_WITH_INCLUDED_KEYS
               = ImmutableMap.of("group", ImmutableMap.of(MBeanSelector.INCLUDED_KEYS_KEY, "a"));
@@ -250,17 +313,39 @@ class MBeanSelectorTest {
 
     @Test
     void whenMapHasSelectedKeysAtMultipleLevels_AddToKeyQuery() {
-        MBeanSelector selector = MBeanSelector.create(DEEP_MAP_WITH_INCLUDED_KEYS);
+        MBeanSelector selector = MBeanSelector.create(DEEP_MAP_WITH_NESTED_INCLUDED_KEYS);
 
         assertThat(selector.getKeyRequest(), hasJsonPath("$.children.groups.fields", contains("groupName")));
-        assertThat(selector.getKeyRequest(), hasJsonPath("$.children.groups.children.subgroup1.fields", contains("name1")));
-        assertThat(selector.getKeyRequest(), hasJsonPath("$.children.groups.children.subgroup2.fields", contains("name2")));
+        assertThat(selector.getKeyRequest(), hasJsonPath("$.children.groups.children.middle.children.subgroup1.fields", contains("name1")));
+        assertThat(selector.getKeyRequest(), hasJsonPath("$.children.groups.children.middle.children.subgroup2.fields", contains("name2")));
     }
 
-    private static final Map<String, Object> DEEP_MAP_WITH_INCLUDED_KEYS = ImmutableMap.of("groups",
-          ImmutableMap.of(MBeanSelector.QUERY_KEY, "groupName", MBeanSelector.INCLUDED_KEYS_KEY, "alpha|beta",
+    private static final Map<String, Object> DEEP_MAP_WITH_NESTED_INCLUDED_KEYS = ImmutableMap.of(MBeanSelector.PREFIX_KEY, "wls_", "groups",
+        ImmutableMap.of(MBeanSelector.QUERY_KEY, "groupName", MBeanSelector.INCLUDED_KEYS_KEY, "alpha|beta",
+            "middle", ImmutableMap.of(
                 "subgroup1", ImmutableMap.of(MBeanSelector.QUERY_KEY, "name1", MBeanSelector.INCLUDED_KEYS_KEY, "abc.*", MBeanSelector.VALUES_KEY, "group1Val" ),
-                "subgroup2", ImmutableMap.of(MBeanSelector.QUERY_KEY, "name2", MBeanSelector.INCLUDED_KEYS_KEY, "def.*", MBeanSelector.VALUES_KEY, "group2Val" )));
+                "subgroup2", ImmutableMap.of(MBeanSelector.QUERY_KEY, "name2", MBeanSelector.INCLUDED_KEYS_KEY, "def.*", MBeanSelector.VALUES_KEY, "group2Val" ))));
+
+    @Test
+    void whenIntermediateLevelLacksSelectedKeys_dontRequestFieldsInKeyQuery() {
+        MBeanSelector selector = MBeanSelector.create(DEEP_MAP_WITH_NESTED_INCLUDED_KEYS);
+
+        assertThat(selector.getKeyRequest(), hasJsonPath("$.children.groups.children.middle.fields", hasSize(0)));
+    }
+
+    @Test
+    void whenNestedEntriesLackFilter_excludeSubTreeFromKeyQuery() {
+        MBeanSelector selector = MBeanSelector.create(DEEP_MAP_WITHOUT_NESTED_INCLUDED_KEYS);
+
+        assertThat(selector.getKeyRequest(), hasJsonPath("$.children.groups.fields", contains("groupName")));
+        assertThat(selector.getKeyRequest(), hasNoJsonPath("$.children.groups.children"));
+    }
+
+    private static final Map<String, Object> DEEP_MAP_WITHOUT_NESTED_INCLUDED_KEYS = ImmutableMap.of("groups",
+        ImmutableMap.of(MBeanSelector.QUERY_KEY, "groupName", MBeanSelector.INCLUDED_KEYS_KEY, "alpha|beta",
+            "middle", ImmutableMap.of(
+                "subgroup1", ImmutableMap.of(MBeanSelector.QUERY_KEY, "name1", MBeanSelector.VALUES_KEY, "group1Val" ),
+                "subgroup2", ImmutableMap.of(MBeanSelector.QUERY_KEY, "name2", MBeanSelector.VALUES_KEY, "group2Val" ))));
 
     @Test
     void whenMapLacksKeyFilter_dontNeedNewKeys() {
@@ -312,6 +397,31 @@ class MBeanSelectorTest {
     }
 
     @Test
+    void afterKeysOfferedThatDoNotMatchFilter_parentSelectorHasNoChildren() {
+        MBeanSelector selector = MBeanSelector.create(MAP_WITH_INCLUDED_KEYS);
+        selector.offerKeys(MISMATCHED_KEY_RESPONSE);
+
+        assertThat(selector.getRequest(), hasNoJsonPath("$.children"));
+    }
+
+    @Test
+    void afterKeysOfferedThatDoNotMatchFilter_parentSelectorHasEmptyFieldsArray() {
+        MBeanSelector selector = MBeanSelector.create(MAP_WITH_INCLUDED_KEYS);
+        selector.offerKeys(MISMATCHED_KEY_RESPONSE);
+
+        assertThat(selector.getRequest(), hasJsonPath("$.fields", hasSize(0)));
+    }
+
+    private static final String MISMATCHED_KEY_RESPONSE_JSON = "{\"servlets\": {\"items\": [\n" +
+                "     {\"servletName\": \"delta\"},\n" +
+                "     {\"servletName\": \"epsilon\" },\n" +
+                "     {\"servletName\": \"zeta\"}\n" +
+                "]}}";
+
+    private static final JsonObject MISMATCHED_KEY_RESPONSE =
+          JsonParser.parseString(MISMATCHED_KEY_RESPONSE_JSON).getAsJsonObject();
+
+    @Test
     void whenMapHasSelectedKeysAtMultipleLevels_specifySelectedKeys() {
         MBeanSelector selector = MBeanSelector.create(DEEP_MAP_WITH_INCLUDED_KEYS);
         selector.offerKeys(DEEP_KEY_RESPONSE);
@@ -320,6 +430,11 @@ class MBeanSelectorTest {
         assertThat(selector.getRequest(), hasJsonPath("$.children.groups.children.subgroup1.name1", containsInAnyOrder("abcdef", "abc123", "abc567")));
         assertThat(selector.getRequest(), hasJsonPath("$.children.groups.children.subgroup2.name2", containsInAnyOrder("defabc", "def123", "def678")));
     }
+
+    private static final Map<String, Object> DEEP_MAP_WITH_INCLUDED_KEYS = ImmutableMap.of("groups",
+          ImmutableMap.of(MBeanSelector.QUERY_KEY, "groupName", MBeanSelector.INCLUDED_KEYS_KEY, "alpha|beta",
+                "subgroup1", ImmutableMap.of(MBeanSelector.QUERY_KEY, "name1", MBeanSelector.INCLUDED_KEYS_KEY, "abc.*", MBeanSelector.VALUES_KEY, "group1Val" ),
+                "subgroup2", ImmutableMap.of(MBeanSelector.QUERY_KEY, "name2", MBeanSelector.INCLUDED_KEYS_KEY, "def.*", MBeanSelector.VALUES_KEY, "group2Val" )));
 
     private static final String DEEP_KEY_RESPONSE_JSON = "{'groups': {'items': [\n" +
           "     {'groupName': 'alpha',\n" +
@@ -356,6 +471,52 @@ class MBeanSelectorTest {
 
     private static final JsonObject DEEP_KEY_RESPONSE =
           JsonParser.parseString(DEEP_KEY_RESPONSE_JSON.replace("'", "\"")).getAsJsonObject();
+
+    @Test
+    void whenMapHasMismatchedNested_specifySelectedKeys() {
+        MBeanSelector selector = MBeanSelector.create(DEEP_MAP_WITH_INCLUDED_KEYS);
+        selector.offerKeys(MISMATCHED_DEEP_KEY_RESPONSE);
+
+        assertThat(selector.getRequest(), hasJsonPath("$.children.groups.groupName", containsInAnyOrder("alpha", "beta")));
+        assertThat(selector.getRequest(), hasJsonPath("$.children.groups.children.subgroup1.name1", containsInAnyOrder("abcdef", "abc123", "abc567")));
+        assertThat(selector.getRequest(), hasNoJsonPath("$.children.groups.children.subgroup2"));
+    }
+
+    private static final String MISMATCHED_DEEP_KEY_RESPONSE_JSON = "{'groups': {'items': [\n" +
+          "     {'groupName': 'alpha',\n" +
+          "      'subgroup1': {'items': [\n" +
+          "          {'name1': 'abcdef'},\n" +
+          "          {'name1': 'abc123'},\n" +
+          "          {'name1': 'ab12_2'}\n" +
+          "       ]},\n" +
+          "      'subgroup2': {'items': [\n" +
+          "          {'name2': 'abcdef'},\n" +
+          "          {'name2': 'xyzabc'},\n" +
+          "          {'name2': 'jklmn'}\n" +
+          "       ]}\n" +
+          "     },\n" +
+          "     {'groupName': 'beta',\n" +
+          "      'subgroup1': {'items': [\n" +
+          "          {'name1': 'abcdef'},\n" +
+          "          {'name1': 'abc567'},\n" +
+          "          {'name1': 'abjkl'}\n" +
+          "       ]},\n" +
+          "      'subgroup2': {'items': [\n" +
+          "          {'name2': 'ghi678'},\n" +
+          "       ]}\n" +
+          "     },\n" +
+          "     {'groupName': 'gamma',\n" +
+          "      'subgroup1': {'items': [\n" +
+          "          {'name1': 'abcxyz'},\n" +
+          "       ]},\n" +
+          "      'subgroup2': {'items': [\n" +
+          "          {'name2': 'jkl987'},\n" +
+          "       ]}\n" +
+          "     }\n" +
+          "]}}";
+
+    private static final JsonObject MISMATCHED_DEEP_KEY_RESPONSE =
+          JsonParser.parseString(MISMATCHED_DEEP_KEY_RESPONSE_JSON.replace("'", "\"")).getAsJsonObject();
 
     @Test
     void whenMapHasBothIncludedAndExcludedKeys_selectKeysLeft() {


### PR DESCRIPTION
Customer (Jose Luis Molina Dueñas) reported problems:

Requesting metrics from 
```
metricsNameSnakeCase: true
domainQualifier: true
queries:
- JDBCServiceRuntime:
    JDBCDataSourceRuntimeMBeans:
      prefix: wls_datasource_
      key: name
      stringValues:
        state: [Running, Suspended, Shutdown, Overloaded, Unknown]
```

fails because the mbean contains a field, `properties`, which requires admin access.

Under some conditions, if a higher-level bean is filtered but no matching keys exist on one server, the request was asking for all beans.

This change attempts to fix both by cleaning up the filtering when there is no match, and by detecting an attempt to request a forbidden field and either removing it from the query if specified, or adding an `excludeFields` element if the containing bean is specified without values.      
