### PR TITLE
Russ always filter on name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Metrics are selected using a [YAML configuration file](#Configuration).
 The exporter is available in two forms:
  - A [web application](#web-application) that you deploy to the server from which metrics are to be extracted.
  You may include a configuration file directly in the WAR file, and you may temporarily modify the configuration in a
- running system by using a web form. If a [coordination configurator](config_coordinator/README.md) is running and configured,
+ running system by using a web form, either by selecting a replacement configuration or one to append to the current one,
+ with the caveat that if both the original and appended configurations have filters, the update will be rejected. 
+ If a [coordination configurator](config_coordinator/README.md) is running and configured,
  that temporary configuration will be sent to all servers configured to use it.
 
  - A [separate process](#sidecar) that is run alongside a server instance. You supply the configuration to such a
@@ -288,7 +290,7 @@ vulnerability disclosure process.
 
 ## License
 
-Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
 Released under the Universal Permissive License v1.0 as shown at
 <https://oss.oracle.com/licenses/upl/>.

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ vulnerability disclosure process.
 
 ## License
 
-Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+Copyright (c) 2019, 2023, Oracle and/or its affiliates.
 
 Released under the Universal Permissive License v1.0 as shown at
 <https://oss.oracle.com/licenses/upl/>.

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WlsRestExchanges.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WlsRestExchanges.java
@@ -8,13 +8,15 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+
 /**
  * A diagnostic class that records requests sent to WLS and the replies received.
  */
 public class WlsRestExchanges {
 
   public static final int MAX_EXCHANGES = 5;
-  private static final String TEMPLATE = "REQUEST to %s:%n%s%nREPLY:%n%s%n";
+  private static final String TEMPLATE = "At %s, REQUEST to %s:%n%s%nREPLY:%n%s%n";
 
   private static final Queue<String> exchanges = new ConcurrentLinkedDeque<>();
 
@@ -35,8 +37,12 @@ public class WlsRestExchanges {
    * @param response the returned JSON string
    */
   public static void addExchange(String url, String request, String response) {
-      exchanges.add(String.format(TEMPLATE, url, request, response));
+      exchanges.add(String.format(TEMPLATE, getCurrentTime(), url, request, response));
       if (exchanges.size() > MAX_EXCHANGES) exchanges.remove();
+  }
+
+  private static String getCurrentTime() {
+    return ISO_LOCAL_TIME.format(SystemClock.now());
   }
 
   /**

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WlsRestExchanges.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/WlsRestExchanges.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/JsonQuerySpec.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/JsonQuerySpec.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import com.google.gson.Gson;
@@ -30,13 +29,18 @@ class JsonQuerySpec {
     private List<String> selectedKeys = null;
     private List<String> excludeFields = null;
 
+    JsonQuerySpec asTopLevel() {
+        addFields();
+        return this;
+    }
+
     /**
      * Specifies the name of any mbean values which should be retrieved.
      * @param newFields the field names to add to any previous defined
      */
     void addFields(String... newFields) {
         if (fields == null) fields = new ArrayList<>();
-        Arrays.stream(newFields).filter(Objects::nonNull).forEach(fields::add);
+        fields.addAll(Arrays.asList(newFields));
     }
 
     /**
@@ -50,8 +54,8 @@ class JsonQuerySpec {
         children.put(name, child);
     }
 
-    void setFilter(String keyName, Set<String> selectedKeys) {
-        this.keyName = keyName;
+    void setFilter(Set<String> selectedKeys) {
+        this.keyName = MBeanSelector.FILTER_KEY;
         this.selectedKeys = new ArrayList<>(selectedKeys);
     }
 

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MBeanSelector.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MBeanSelector.java
@@ -364,7 +364,7 @@ public class MBeanSelector {
             selectQueryFields(spec, getQueryValues());
         }
         if (currentSelectorHasFilter() && !filter.isEmpty())
-            spec.setFilter(FILTER_KEY, filter);
+            spec.setFilter(filter);
 
         for (Map.Entry<String, MBeanSelector> entry : nestedSelectors.entrySet())
             if (entry.getValue().isEnabled())

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MBeanSelector.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MBeanSelector.java
@@ -108,7 +108,6 @@ public class MBeanSelector {
                     break;
             }
         }
-        validate();
     }
 
     private void addNestedSelector(String key, Object selectorValue) {
@@ -161,13 +160,6 @@ public class MBeanSelector {
             if (!duplicates.isEmpty())
                 throw new ConfigurationException("Duplicate string values " + duplicates + " for " + stringValue.getKey());
         }
-    }
-
-    private void validate() {
-        if (getKey() == null && includedKeys != null)
-            throw new ConfigurationException("Included key values specified without key field");
-        if (getKey() == null && excludedKeys != null)
-            throw new ConfigurationException("Excluded key values specified without key field");
     }
 
     /**
@@ -517,10 +509,16 @@ public class MBeanSelector {
     }
 
     private MBeanSelector(MBeanSelector first, MBeanSelector second) {
+        rejectConflicts(first, second);
         copyScalars(first);
         combineValues(first, second);
         combineStringValues(first, second);
         combineNestedSelectors(first, second);
+    }
+
+    private void rejectConflicts(MBeanSelector first, MBeanSelector second) {
+        if (first.hasFilter() && second.hasFilter())
+            throw new ConfigurationException("May not merge configurations when both have filters.");
     }
 
     private void copyScalars(MBeanSelector first) {

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MBeanSelectorTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MBeanSelectorTest.java
@@ -40,6 +40,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -678,7 +679,7 @@ class MBeanSelectorTest {
         MBeanSelector selector1 = createSelectorWithTopLevelFilter();
         MBeanSelector selector2 = createSelectorWithoutFilter();
 
-        selector1.merge(selector2);
+        assertDoesNotThrow(() -> selector1.merge(selector2));
     }
 
     @Test
@@ -686,7 +687,7 @@ class MBeanSelectorTest {
         MBeanSelector selector1 = createSelectorWithoutFilter();
         MBeanSelector selector2 = createSelectorWithSecondLevelFilter();
 
-        selector1.merge(selector2);
+        assertDoesNotThrow(() -> selector1.merge(selector2));
     }
 
     @Test

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MBeanSelectorTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MBeanSelectorTest.java
@@ -40,6 +40,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Russell Gold
@@ -670,6 +671,24 @@ class MBeanSelectorTest {
         assertThat(result.getKeyName(), equalTo("numbers"));
         assertThat(result.getIncludedKeys(), equalTo(INCLUDED));
         assertThat(result.getExcludedKeys(), equalTo(EXCLUDED));
+    }
+
+    @Test
+    void whenBothConfigurationsHaveFilters_rejectMerge() {
+        MBeanSelector selector1 = createSelectorWithTopLevelFilter();
+        MBeanSelector selector2 = createSelectorWithSecondLevelFilter();
+
+        assertThrows(ConfigurationException.class, () -> selector1.merge(selector2));
+    }
+
+    private MBeanSelector createSelectorWithTopLevelFilter() {
+        return MBeanSelector.create(ImmutableMap.of("includedKeyValues", "Abcd", "servlets",
+                ImmutableMap.of(MBeanSelector.VALUES_KEY, new String[] {"first", "second"})));
+    }
+
+    private MBeanSelector createSelectorWithSecondLevelFilter() {
+        return MBeanSelector.create(ImmutableMap.of("servlets",
+                ImmutableMap.of("excludedKeyValues", "A.*", MBeanSelector.VALUES_KEY, new String[] {"first", "second"})));
     }
 
     @Test

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MBeanSelectorTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MBeanSelectorTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
@@ -186,6 +187,12 @@ class MBeanSelectorTest {
 
     private Map<String, Serializable> getServletMap() {
         return ImmutableMap.of(MBeanSelector.QUERY_KEY, EXPECTED_KEY, MBeanSelector.VALUES_KEY, EXPECTED_VALUES);
+    }
+
+    @Test
+    void whenTopLevelSelectorDoesNotSpecifyValues_doNotSpecifyFields() {
+        MBeanSelector selector = MBeanSelector.create(DEEP_MAP);
+        assertThat(querySpec(selector), hasJsonPath("$.fields", empty()));
     }
 
     @Test

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MBeanSelectorTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MBeanSelectorTest.java
@@ -674,11 +674,32 @@ class MBeanSelectorTest {
     }
 
     @Test
+    void whenOnlyInitialConfigurationHasFilters_permitMerge() {
+        MBeanSelector selector1 = createSelectorWithTopLevelFilter();
+        MBeanSelector selector2 = createSelectorWithoutFilter();
+
+        selector1.merge(selector2);
+    }
+
+    @Test
+    void whenOnlySecondConfigurationsHasFilters_permitMerge() {
+        MBeanSelector selector1 = createSelectorWithoutFilter();
+        MBeanSelector selector2 = createSelectorWithSecondLevelFilter();
+
+        selector1.merge(selector2);
+    }
+
+    @Test
     void whenBothConfigurationsHaveFilters_rejectMerge() {
         MBeanSelector selector1 = createSelectorWithTopLevelFilter();
         MBeanSelector selector2 = createSelectorWithSecondLevelFilter();
 
         assertThrows(ConfigurationException.class, () -> selector1.merge(selector2));
+    }
+
+    private MBeanSelector createSelectorWithoutFilter() {
+        return MBeanSelector.create(ImmutableMap.of("servlets",
+                ImmutableMap.of(MBeanSelector.VALUES_KEY, new String[] {"first", "second"})));
     }
 
     private MBeanSelector createSelectorWithTopLevelFilter() {

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/webapp/ConfigurationServletTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/webapp/ConfigurationServletTest.java
@@ -114,6 +114,13 @@ class ConfigurationServletTest {
             "    key: name\n" +
             "    values: [age, sex]\n";
 
+    private static final String FILTERED_CONFIGURATION1 =
+            "queries:\n" + "" +
+            "- groups:\n" +
+            "    prefix: new_\n" +
+            "    key: name\n" +
+            "    values: [sample1, sample2]\n";
+
     @Test
     void whenPostWithoutFile_reportFailure() {
         assertThrows(ServletException.class, () -> servlet.doPost(createPostRequest(), response));

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/webapp/ConfigurationServletTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/webapp/ConfigurationServletTest.java
@@ -114,13 +114,6 @@ class ConfigurationServletTest {
             "    key: name\n" +
             "    values: [age, sex]\n";
 
-    private static final String FILTERED_CONFIGURATION1 =
-            "queries:\n" + "" +
-            "- groups:\n" +
-            "    prefix: new_\n" +
-            "    key: name\n" +
-            "    values: [sample1, sample2]\n";
-
     @Test
     void whenPostWithoutFile_reportFailure() {
         assertThrows(ServletException.class, () -> servlet.doPost(createPostRequest(), response));


### PR DESCRIPTION
It turns out that the REST API requires all filtering to be on the `name` field (with a possible exception of some beans which don't appear to be runtime mbeans). This change uses that standard field name rather than the selected `key` field.