### PR TITLE
Enhance string metrics to include the actual value

### DIFF
--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MetricsScraper.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/domain/MetricsScraper.java
@@ -100,14 +100,19 @@ class MetricsScraper {
 
         private void scrapeItem() {
             if (excludeByType()) return;
-            String itemQualifiers = getItemQualifiers();
+            final String itemQualifiers = getItemQualifiers();
 
             for (String valueName : getValueNames()) {
-                if (valueName.equals(selector.getKey())) continue;
-                JsonElement value = object.get(valueName);
-                addMetric(itemQualifiers, valueName, value);
+                scrapeValue(itemQualifiers, valueName);
             }
+
             scrapeSubObjects(itemQualifiers);
+        }
+
+        private void scrapeValue(String itemQualifiers, String valueName) {
+            if (valueName.equals(selector.getKey())) return;
+
+            new ScrapedMetric(itemQualifiers, valueName).add();
         }
 
         private boolean excludeByType() {
@@ -133,21 +138,17 @@ class MetricsScraper {
             return QUOTE + jsonElement.getAsString() + QUOTE;
         }
 
-        private void addMetric(String itemQualifiers, String valueName, JsonElement value) {
-            new ScrapedMetric(itemQualifiers, valueName, value).add();
-        }
-
 
         class ScrapedMetric {
+            private final String itemQualifiers;
+            private final String valueName;
             private final JsonPrimitive jsonPrimitive;
-            String itemQualifiers;
-            String valueName;
 
-            ScrapedMetric(String itemQualifiers, String valueName, JsonElement value) {
+            ScrapedMetric(String itemQualifiers, String valueName) {
                 this.itemQualifiers = itemQualifiers;
                 this.valueName = valueName;
 
-                this.jsonPrimitive = Optional.ofNullable(value)
+                this.jsonPrimitive = Optional.ofNullable(object.get(valueName))
                       .filter(JsonElement::isJsonPrimitive)
                       .map(JsonElement::getAsJsonPrimitive)
                       .orElse(null);

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ExporterServletTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/ExporterServletTest.java
@@ -353,12 +353,12 @@ class ExporterServletTest {
 
         servlet.doGet(request, this.response);
 
-        assertThat(toHtml(this.response), containsString("color{name=\"fred\"} 0"));
-        assertThat(toHtml(this.response), containsString("color{name=\"george\"} 1"));
-        assertThat(toHtml(this.response), containsString("color{name=\"ron\"} -1"));
-        assertThat(toHtml(this.response), containsString("size{name=\"fred\"} 0"));
-        assertThat(toHtml(this.response), containsString("size{name=\"george\"} 1"));
-        assertThat(toHtml(this.response), containsString("size{name=\"ron\"} 2"));
+        assertThat(toHtml(this.response), containsString("color{name=\"fred\",value=\"red\"} 0"));
+        assertThat(toHtml(this.response), containsString("color{name=\"george\",value=\"green\"} 1"));
+        assertThat(toHtml(this.response), containsString("color{name=\"ron\",value=\"blue\"} -1"));
+        assertThat(toHtml(this.response), containsString("size{name=\"fred\",value=\"tall\"} 0"));
+        assertThat(toHtml(this.response), containsString("size{name=\"george\",value=\"grande\"} 1"));
+        assertThat(toHtml(this.response), containsString("size{name=\"ron\",value=\"venti\"} 2"));
     }
 
     private Map<String,Object> getStringResponseMap() {

--- a/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MetricsScraperTest.java
+++ b/wls-exporter-core/src/test/java/com/oracle/wls/exporter/domain/MetricsScraperTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter.domain;
@@ -202,13 +202,13 @@ class MetricsScraperTest {
     }
 
     @Test
-    void whenStringValuesSpecified_generateEnumeration() {
+    void whenStringValuesSpecified_generateEnumerationAndQualifier() {
         generateNestedMetrics(getStringValuedServletsMap(), SERVLET_RESPONSE);
 
         assertThat(scraper.getMetrics(),
-                   allOf(hasMetric("servlet_state{servletName=\"JspServlet\"}", 1),
-                         hasMetric("servlet_state{servletName=\"FileServlet\"}", 0),
-                         hasMetric("servlet_state{servletName=\"ready\"}", 2)));
+                   allOf(hasMetric("servlet_state{servletName=\"JspServlet\",value=\"running\"}", 1),
+                         hasMetric("servlet_state{servletName=\"FileServlet\",value=\"stopped\"}", 0),
+                         hasMetric("servlet_state{servletName=\"ready\",value=\"confused\"}", 2)));
     }
 
     private ImmutableMap<String, Object> getStringValuedServletsMap() {


### PR DESCRIPTION
Enhances the handling of string metrics so that the actual string value is part of the metric. Thus, for example, 
```
servlet_state{servletName="JspServlet",value="running"} 1
```

the string metric name is `servlet_state`, the key name is `servletName`, the value of the key is "JspServlet" and the string metric has the value "running" which is mapped to _1_.