### PR TITLE
Use unique name for version property

### DIFF
--- a/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/GitTagMojo.java
+++ b/build-helper-mojo/src/main/java/com/oracle/wls/buildhelper/GitTagMojo.java
@@ -20,7 +20,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 @Mojo(name = "gitVersion", defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
 public class GitTagMojo extends AbstractMojo {
 
-  @Parameter(required = true, defaultValue = "${project.build.outputDirectory}/version.properties")
+  @Parameter(required = true, defaultValue = "${project.build.outputDirectory}/exporter-version.properties")
   private File outputFile;
   
   private final GitTagExecutor executor;
@@ -48,7 +48,7 @@ public class GitTagMojo extends AbstractMojo {
   }
 
   private List<String> createProperties(String versionString) {
-    return Collections.singletonList("version=" + versionString);
+    return Collections.singletonList("monitoring-exporter-version=" + versionString);
   }
 
   // parses the result of 'git describe --tag' to describe the current code version/

--- a/build-helper-mojo/src/test/java/com/oracle/wls/buildhelper/GitTagMojoTest.java
+++ b/build-helper-mojo/src/test/java/com/oracle/wls/buildhelper/GitTagMojoTest.java
@@ -61,7 +61,7 @@ class GitTagMojoTest {
   void hasRequiredOutputDirectoryParameter() throws NoSuchFieldException {
     assertThat(mojoTestSupport.getParameterField("outputFile").getType(), equalTo(File.class));
     assertThat(mojoTestSupport.getParameterAnnotation("outputFile").get("required"), is(true));
-    assertThat(mojoTestSupport.getParameterAnnotation("outputFile").get("defaultValue"), equalTo("${project.build.outputDirectory}/version.properties"));
+    assertThat(mojoTestSupport.getParameterAnnotation("outputFile").get("defaultValue"), equalTo("${project.build.outputDirectory}/exporter-version.properties"));
   }
 
   @Test
@@ -92,7 +92,7 @@ class GitTagMojoTest {
     mojo.execute();
 
     assertThat(inMemoryFileSystem.getContents(outputFile.getAbsolutePath()),
-          containsString("version=cb4385f3aa (946 commits since v3.3.5-3)"));
+          containsString("monitoring-exporter-version=cb4385f3aa (946 commits since v3.3.5-3)"));
   }
 
   @Test
@@ -101,7 +101,8 @@ class GitTagMojoTest {
 
     mojo.execute();
 
-    assertThat(inMemoryFileSystem.getContents(outputFile.getAbsolutePath()), containsString("version=v3.4-1"));
+    assertThat(inMemoryFileSystem.getContents(outputFile.getAbsolutePath()),
+          containsString("monitoring-exporter-version=v3.4-1"));
   }
 
   @Test

--- a/wls-exporter-core/src/main/java/com/oracle/wls/exporter/LiveConfiguration.java
+++ b/wls-exporter-core/src/main/java/com/oracle/wls/exporter/LiveConfiguration.java
@@ -1,14 +1,7 @@
-// Copyright (c) 2017, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2017, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.wls.exporter;
-
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.oracle.wls.exporter.domain.ExporterConfig;
-import com.oracle.wls.exporter.domain.MBeanSelector;
-import com.oracle.wls.exporter.domain.QuerySyncConfiguration;
-import org.yaml.snakeyaml.Yaml;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -19,12 +12,22 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.oracle.wls.exporter.domain.ExporterConfig;
+import com.oracle.wls.exporter.domain.MBeanSelector;
+import com.oracle.wls.exporter.domain.QuerySyncConfiguration;
+import org.yaml.snakeyaml.Yaml;
+
 /**
  * The repository for the current exporter configuration.
  *
  * @author Russell Gold
  */
 public class LiveConfiguration {
+
+    public static final String VERSION_PROPERTY_FILE = "exporter-version.properties";
+    public static final String VERSION_PROPERTY = "monitoring-exporter-version";
 
     private LiveConfiguration() {
         // no-op
@@ -59,10 +62,10 @@ public class LiveConfiguration {
     }
 
     public static String getVersionString() {
-        try (InputStream in = LiveConfiguration.class.getClassLoader().getResourceAsStream("version.properties")) {
+        try (InputStream in = LiveConfiguration.class.getClassLoader().getResourceAsStream(VERSION_PROPERTY_FILE)) {
             Properties properties = new Properties();
             properties.load(in);
-            return properties.getProperty("version");
+            return properties.getProperty(VERSION_PROPERTY);
 
         } catch (IOException e) {
             return "** unknown version";


### PR DESCRIPTION
As noted in issue #256,  the property used to record the exporter version seems to be in use elsewhere in an FMW environment, so we need to change it to something unlikely to be in use.